### PR TITLE
<README/build_deps: Add pkg-config to required dependencies for build>

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Install dependencies:
 * pango
 * cairo
 * systemd or elogind (for the sd-bus library)
+* pkg-config
 
 Then run:
 


### PR DESCRIPTION
I believe that pkg-config is also required to build mako.