### PR TITLE
makoctl dismiss

### DIFF
--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -12,7 +12,7 @@
 static const char *service_path = "/fr/emersion/Mako";
 static const char *service_interface = "fr.emersion.Mako";
 
-static int handle_close_all_notifications(sd_bus_message *msg, void *data,
+static int handle_dismiss_all_notifications(sd_bus_message *msg, void *data,
 		sd_bus_error *ret_error) {
 	struct mako_state *state = data;
 
@@ -30,7 +30,7 @@ done:
 	return sd_bus_reply_method_return(msg, "");
 }
 
-static int handle_close_last_notification(sd_bus_message *msg, void *data,
+static int handle_dismiss_last_notification(sd_bus_message *msg, void *data,
 		sd_bus_error *ret_error) {
 	struct mako_state *state = data;
 
@@ -49,8 +49,8 @@ done:
 
 static const sd_bus_vtable service_vtable[] = {
 	SD_BUS_VTABLE_START(0),
-	SD_BUS_METHOD("CloseAllNotifications", "", "", handle_close_all_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("CloseLastNotification", "", "", handle_close_last_notification, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("DismissAllNotifications", "", "", handle_dismiss_all_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("DismissLastNotification", "", "", handle_dismiss_last_notification, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END
 };
 

--- a/makoctl
+++ b/makoctl
@@ -4,8 +4,8 @@ usage() {
 	echo "Usage: makoctl <command> [options...]"
 	echo ""
 	echo "Commands:"
-	echo "  close [-a|--all]  Close the last or all notifications"
-	echo "  help              Show this help"
+	echo "  dismiss [-a|--all] Dismiss the last or all notifications"
+	echo "  help               Show this help"
 }
 
 call() {
@@ -14,7 +14,7 @@ call() {
 }
 
 case "$1" in
-"close")
+"dismiss")
 	case "$2" in
 	"-a"|"--all")
 		call CloseAllNotifications

--- a/makoctl.1.scd
+++ b/makoctl.1.scd
@@ -14,7 +14,7 @@ Sends IPC commands to the running mako daemon via dbus.
 
 # COMMANDS
 
-*close*
+*dismiss*
 	Dismisses the oldest notification.
 
 	*Options*


### PR DESCRIPTION
"Close" can have a variety of meanings (per enum
mako_notification_close_reason) but the ones that come from makoctl are
always dismissal. I think dismiss makes more sense for this command.