### PR TITLE
Create a new cairo path for each notification

### DIFF
--- a/render.c
+++ b/render.c
@@ -102,6 +102,11 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	pango_cairo_update_layout(cairo, layout);
 	pango_cairo_show_layout(cairo, layout);
 
+	// Reset the cairo path between each notification, otherwise subsequent
+	// borders will be drawn along all notifications, causing them to become
+	// visually thicker.
+	cairo_new_path(cairo);
+
 	g_object_unref(layout);
 
 	return notif_height;


### PR DESCRIPTION
I've still been investigating why borders get thicker in between adjacent notifications. In the process, I found that they were accidentally being drawn multiple times along each notification. This was invisible since the fill is then drawn over top. I still haven't solved the original issue, but I figured this was worth getting fixed in the meantime.

I don't know enough cairo to know why this is the correct solution instead of cairo_close_path, but this is the one that worked.