### PR TITLE
[WIP] Per-notification style

### DIFF
--- a/criteria.c
+++ b/criteria.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <wayland-client.h>
+#include "mako.h"
+#include "criteria.h"
+#include "notification.h"
+
+struct mako_criteria *create_criteria(struct mako_state *state) {
+	struct mako_criteria *criteria = calloc(1, sizeof(struct mako_criteria));
+	if (criteria == NULL) {
+		fprintf(stderr, "allocation failed\n");
+		return NULL;
+	}
+
+	// Copy the global configuration, which will then be overridden as needed
+	// during the configuration of this criteria.
+	*criteria->config = state->config;
+	return criteria;
+}
+
+void finish_criteria(struct mako_criteria *criteria) {
+	free(criteria->app_name);
+	free(criteria->app_icon);
+	free(criteria->category);
+	free(criteria->desktop_entry);
+}
+
+bool match_criteria(struct mako_criteria *criteria,
+		struct mako_notification *notif) {
+	return false;
+}

--- a/criteria.c
+++ b/criteria.c
@@ -29,5 +29,37 @@ void finish_criteria(struct mako_criteria *criteria) {
 
 bool match_criteria(struct mako_criteria *criteria,
 		struct mako_notification *notif) {
-	return false;
+	struct mako_criteria_spec spec = criteria->specified;
+
+	if (spec.app_name &&
+			strcmp(criteria->app_name, notif->app_name) != 0) {
+		return false;
+	}
+
+	if (spec.app_icon &&
+			strcmp(criteria->app_icon, notif->app_icon) != 0) {
+		return false;
+	}
+
+	if (spec.actionable &&
+			criteria->actionable == wl_list_empty(&notif->actions)) {
+		return false;
+	}
+
+	if (spec.urgency &&
+			criteria->urgency != notif->urgency) {
+		return false;
+	}
+
+	if (spec.category &&
+			strcmp(criteria->category, notif->category) != 0) {
+		return false;
+	}
+
+	if (spec.desktop_entry &&
+			strcmp(criteria->desktop_entry, notif->desktop_entry) != 0) {
+		return false;
+	}
+
+	return true;
 }

--- a/include/config.h
+++ b/include/config.h
@@ -24,6 +24,8 @@ enum mako_sort_criteria {
 };
 
 struct mako_config {
+	// Configurable per notification
+
 	char *font;
 	int32_t width, height;
 	int32_t padding;
@@ -32,11 +34,6 @@ struct mako_config {
 	char *format;
 	bool actions;
 	struct mako_directional margin;
-	int32_t max_visible;
-	char *output;
-	char *hidden_format;
-	uint32_t sort_criteria; //enum mako_sort_criteria
-	uint32_t sort_asc;
 
 	int default_timeout; // in ms
 
@@ -45,6 +42,14 @@ struct mako_config {
 		uint32_t text;
 		uint32_t border;
 	} colors;
+
+	// Always global (but still copied into per-notification structs)
+
+	int32_t max_visible;
+	char *output;
+	char *hidden_format;
+	uint32_t sort_criteria; //enum mako_sort_criteria
+	uint32_t sort_asc;
 
 	struct {
 		enum mako_button_binding left, right, middle;

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -1,0 +1,45 @@
+#ifndef _MAKO_CRITERIA_H
+#define _MAKO_CRITERIA_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "notification.h"
+
+struct mako_config;
+
+// Stores whether or not each field was part of the criteria specification, so
+// that, for example, "not actionable" can be distinguished from "don't care".
+// This is unnecessary for string fields, but it's best to just keep it
+// consistent.
+struct mako_criteria_spec {
+	bool app_name;
+	bool app_icon;
+	bool actionable;
+	bool urgency;
+	bool category;
+	bool desktop_entry;
+};
+
+struct mako_criteria {
+	// Configuration to apply to matches:
+	struct mako_config *config;
+
+	// Fields that were specified:
+	struct mako_criteria_spec specified;
+
+	// Fields that can be matched:
+	char *app_name;
+	char *app_icon;
+	bool actionable; // Whether mako_notification.actions is nonempty
+
+	enum mako_notification_urgency urgency;
+	char *category;
+	char *desktop_entry;
+};
+
+struct mako_criteria *create_criteria(struct mako_state *state);
+void finish_criteria(struct mako_criteria *criteria);
+bool match_criteria(struct mako_criteria *criteria,
+		struct mako_notification *notif);
+
+#endif

--- a/include/notification.h
+++ b/include/notification.h
@@ -13,6 +13,7 @@ enum mako_notification_urgency {
 };
 
 struct mako_state;
+struct mako_config;
 struct mako_timer;
 
 struct mako_hotspot {
@@ -23,6 +24,8 @@ struct mako_hotspot {
 struct mako_notification {
 	struct mako_state *state;
 	struct wl_list link; // mako_state::notifications
+
+	struct mako_config *config;
 
 	uint32_t id;
 	char *app_name;

--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,7 @@ executable(
 		'pool-buffer.c',
 		'render.c',
 		'wayland.c',
+		'criteria.c',
 	]),
 	dependencies: [
 		cairo,

--- a/notification.c
+++ b/notification.c
@@ -33,6 +33,7 @@ struct mako_notification *create_notification(struct mako_state *state) {
 
 	notif->state = state;
 	++state->last_id;
+	notif->config = &state->config; // Assume global configuration.
 	notif->id = state->last_id;
 	wl_list_init(&notif->actions);
 	notif->urgency = MAKO_NOTIFICATION_URGENCY_UNKNOWN;

--- a/render.c
+++ b/render.c
@@ -35,10 +35,8 @@ static void set_rectangle(cairo_t *cairo, int x, int y, int width, int height,
 	cairo_rectangle(cairo, x * scale, y * scale, width * scale, height * scale);
 }
 
-static int render_notification(cairo_t *cairo, struct mako_state *state,
+static int render_notification(cairo_t *cairo, struct mako_config *config,
 		const char *text, int offset_y, int scale) {
-	struct mako_config *config = &state->config;
-
 	int border_size = 2 * config->border_size;
 	int padding_size = 2 * config->padding;
 
@@ -153,7 +151,7 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 		}
 
 		int notif_height =
-			render_notification(cairo, state, text, total_height, scale);
+			render_notification(cairo, config, text, total_height, scale);
 		free(text);
 
 		// Update hotspot
@@ -184,7 +182,7 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 		format_text(config->hidden_format, text, format_state_text, state);
 
 		int hidden_height =
-			render_notification(cairo, state, text, total_height, scale);
+			render_notification(cairo, config, text, total_height, scale);
 		free(text);
 
 		total_height += hidden_height;

--- a/render.c
+++ b/render.c
@@ -138,8 +138,12 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 	int total_height = 0;
 	struct mako_notification *notif;
 	wl_list_for_each(notif, &state->notifications, link) {
+		// Use each notification's config while rendering it.
+		config = notif->config;
+
 		size_t text_len =
 			format_text(config->format, NULL, format_notif_text, notif);
+
 		char *text = malloc(text_len + 1);
 		if (text == NULL) {
 			break;
@@ -168,6 +172,9 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 			break;
 		}
 	}
+
+	// Use the global config again after finishing all the notifications.
+	config = &state->config;
 
 	if (wl_list_length(&state->notifications) > config->max_visible) {
 		total_height += inner_margin;

--- a/render.c
+++ b/render.c
@@ -88,7 +88,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	set_rectangle(cairo,
 		config->border_size / 2.0,
 		offset_y + config->border_size / 2.0,
-		state->width - config->border_size,
+		config->width - config->border_size,
 		notif_height - config->border_size, scale);
 	cairo_save(cairo);
 	cairo_set_line_width(cairo, config->border_size * scale);
@@ -99,7 +99,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	set_source_u32(cairo, config->colors.background);
 	set_rectangle(cairo,
 		config->border_size, offset_y + config->border_size,
-		state->width - border_size, notif_height - border_size, scale);
+		config->width - border_size, notif_height - border_size, scale);
 	cairo_fill(cairo);
 
 	// Render text


### PR DESCRIPTION
Work towards #3. Posting it early to get feedback on the structure I've chosen, and also just because I've got a lot going on in real life and I don't want to just have radio silence over the next couple weeks.

List of things done, and things left to do:
- [x] Render each notification using its associated config
- [x] Add `mako_criteria` and match logic for each applicable notification field
    - [x] `app_name`
    - [x] `app_icon`
    - [x] `actionable` (whether the actions list is nonempty)
    - [x] `urgency`
    - [x] `category`
    - [x] `desktop_entry`
    - ~`summary`~ (pcre)
    - ~`body`~ (pcre)
- [ ] Add criteria support to configuration parser
    - [ ] Convert hidden to a criteria
- [ ] Store criteria structs on `mako_state`
- [ ] Rework global configuration to be an empty criteria
- [ ] Check for criteria matches in `create_notification` and set the notification's config
- [ ] Adjust rendering for differently-sized notifications
    - [ ] Calculate maximum border + padding + margin for size of surface (just resize on the fly?)
    - [ ] Anchor smaller notifications along the same edge as the surface
- [ ] Allow choosing output per-notification
    - [ ] Loop over outputs in send_frame
    - [ ] Make render take the output (replacing `scale`), and only draw appropriate notifications

Things I'm not sure about:
- [ ] Can we match on how close a timer is to expiring? (e.g., have notifications visibly age.)
- [ ] Should `max_visible` be settable in criteria? We would have to decide on how the criteria setting interacts with the global one.
- [ ] How should notifications that match multiple criteria be handled? Does the last defined criteria "win" if multiple set the same option? Or do we want some other priority?