### PR TITLE
Hidden notification format

### DIFF
--- a/config.c
+++ b/config.c
@@ -41,6 +41,7 @@ void init_config(struct mako_config *config) {
 void finish_config(struct mako_config *config) {
 	free(config->font);
 	free(config->format);
+	free(config->hidden_format);
 	free(config->output);
 }
 

--- a/config.c
+++ b/config.c
@@ -19,7 +19,7 @@ void init_config(struct mako_config *config) {
 	config->border_size = 1;
 	config->markup = true;
 	config->format = strdup("<b>%s</b>\n%b");
-	config->hidden_format = strdup("[%h]");
+	config->hidden_format = strdup("%t[%h]");
 	config->actions = true;
 
 	config->margin.top = 10;

--- a/config.c
+++ b/config.c
@@ -19,12 +19,14 @@ void init_config(struct mako_config *config) {
 	config->border_size = 1;
 	config->markup = true;
 	config->format = strdup("<b>%s</b>\n%b");
+	config->hidden_format = strdup("[%h]");
 	config->actions = true;
 
 	config->margin.top = 10;
 	config->margin.right = 10;
 	config->margin.bottom = 10;
 	config->margin.left = 10;
+	config->hidden_margin = 3;
 
 	config->max_visible = 5;
 	config->output = strdup("");

--- a/config.c
+++ b/config.c
@@ -161,6 +161,10 @@ static int apply_config_option(struct mako_config *config,
 		free(config->format);
 		config->format = strdup(value);
 		return 0;
+	} else if (strcmp(name, "hidden-format") == 0) {
+		free(config->hidden_format);
+		config->hidden_format = strdup(value);
+		return 0;
 	} else if (strcmp(name, "max-visible") == 0) {
 		config->max_visible = strtol(value, NULL, 10);
 		return 0;
@@ -282,6 +286,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"border-color", required_argument, 0, 0},
 		{"markup", required_argument, 0, 0},
 		{"format", required_argument, 0, 0},
+		{"hidden-format", required_argument, 0, 0},
 		{"max-visible", required_argument, 0, 0},
 		{"default-timeout", required_argument, 0, 0},
 		{"output", required_argument, 0, 0},

--- a/config.c
+++ b/config.c
@@ -26,7 +26,6 @@ void init_config(struct mako_config *config) {
 	config->margin.right = 10;
 	config->margin.bottom = 10;
 	config->margin.left = 10;
-	config->hidden_margin = 3;
 
 	config->max_visible = 5;
 	config->output = strdup("");

--- a/include/config.h
+++ b/include/config.h
@@ -29,6 +29,8 @@ struct mako_config {
 	struct mako_directional margin;
 	int32_t max_visible;
 	char *output;
+	char *hidden_format;
+	int32_t hidden_margin;
 
 	int default_timeout; // in ms
 

--- a/include/config.h
+++ b/include/config.h
@@ -30,7 +30,6 @@ struct mako_config {
 	int32_t max_visible;
 	char *output;
 	char *hidden_format;
-	int32_t hidden_margin;
 
 	int default_timeout; // in ms
 

--- a/include/notification.h
+++ b/include/notification.h
@@ -55,6 +55,8 @@ enum mako_notification_close_reason {
 
 #define DEFAULT_ACTION_KEY "default"
 
+typedef const char *(*mako_format_func_t)(char variable, void *data);
+
 bool hotspot_at(struct mako_hotspot *hotspot, int32_t x, int32_t y);
 
 struct mako_notification *create_notification(struct mako_state *state);
@@ -63,10 +65,12 @@ void close_notification(struct mako_notification *notif,
 	enum mako_notification_close_reason reason);
 void close_all_notifications(struct mako_state *state,
 	enum mako_notification_close_reason reason);
+const char* format_notif_text(char variable, void *data);
+size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data);
 struct mako_notification *get_notification(struct mako_state *state, uint32_t id);
 size_t format_notification(struct mako_state *state, struct mako_notification *notif, const char *format,
 		char *buf);
 void notification_handle_button(struct mako_notification *notif, uint32_t button,
-	enum wl_pointer_button_state state);
+		enum wl_pointer_button_state state);
 
 #endif

--- a/include/notification.h
+++ b/include/notification.h
@@ -72,6 +72,6 @@ struct mako_notification *get_notification(struct mako_state *state, uint32_t id
 size_t format_notification(struct mako_notification *notif, const char *format,
 	char *buf);
 void notification_handle_button(struct mako_notification *notif, uint32_t button,
-		enum wl_pointer_button_state state);
+	enum wl_pointer_button_state state);
 
 #endif

--- a/include/notification.h
+++ b/include/notification.h
@@ -9,7 +9,7 @@ enum mako_notification_urgency {
 	MAKO_NOTIFICATION_URGENCY_LOW = 0,
 	MAKO_NOTIFICATION_URGENCY_NORMAL = 1,
 	MAKO_NOTIFICATION_URGENCY_HIGH = 2,
-	MAKO_NOTIFICATION_URGENCY_UNKNWON = -1,
+	MAKO_NOTIFICATION_URGENCY_UNKNOWN = -1,
 };
 
 struct mako_state;
@@ -65,8 +65,8 @@ void close_notification(struct mako_notification *notif,
 	enum mako_notification_close_reason reason);
 void close_all_notifications(struct mako_state *state,
 	enum mako_notification_close_reason reason);
-const char *format_state_text(char variable, void *data);
-const char *format_notif_text(char variable, void *data);
+char *format_state_text(char variable, void *data);
+char *format_notif_text(char variable, void *data);
 size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data);
 struct mako_notification *get_notification(struct mako_state *state, uint32_t id);
 size_t format_notification(struct mako_notification *notif, const char *format,

--- a/include/notification.h
+++ b/include/notification.h
@@ -64,8 +64,8 @@ void close_notification(struct mako_notification *notif,
 void close_all_notifications(struct mako_state *state,
 	enum mako_notification_close_reason reason);
 struct mako_notification *get_notification(struct mako_state *state, uint32_t id);
-size_t format_notification(struct mako_notification *notif, const char *format,
-	char *buf);
+size_t format_notification(struct mako_state *state, struct mako_notification *notif, const char *format,
+		char *buf);
 void notification_handle_button(struct mako_notification *notif, uint32_t button,
 	enum wl_pointer_button_state state);
 

--- a/include/notification.h
+++ b/include/notification.h
@@ -72,6 +72,6 @@ struct mako_notification *get_notification(struct mako_state *state, uint32_t id
 size_t format_notification(struct mako_notification *notif, const char *format,
 	char *buf);
 void notification_handle_button(struct mako_notification *notif, uint32_t button,
-	enum wl_pointer_button_state state);
+		enum wl_pointer_button_state state);
 
 #endif

--- a/include/notification.h
+++ b/include/notification.h
@@ -65,7 +65,8 @@ void close_notification(struct mako_notification *notif,
 	enum mako_notification_close_reason reason);
 void close_all_notifications(struct mako_state *state,
 	enum mako_notification_close_reason reason);
-const char* format_notif_text(char variable, void *data);
+const char *format_state_text(char variable, void *data);
+const char *format_notif_text(char variable, void *data);
 size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data);
 struct mako_notification *get_notification(struct mako_state *state, uint32_t id);
 size_t format_notification(struct mako_state *state, struct mako_notification *notif, const char *format,

--- a/include/notification.h
+++ b/include/notification.h
@@ -70,8 +70,8 @@ const char *format_notif_text(char variable, void *data);
 size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data);
 struct mako_notification *get_notification(struct mako_state *state, uint32_t id);
 size_t format_notification(struct mako_notification *notif, const char *format,
-		char *buf);
+	char *buf);
 void notification_handle_button(struct mako_notification *notif, uint32_t button,
-		enum wl_pointer_button_state state);
+	enum wl_pointer_button_state state);
 
 #endif

--- a/include/notification.h
+++ b/include/notification.h
@@ -55,7 +55,7 @@ enum mako_notification_close_reason {
 
 #define DEFAULT_ACTION_KEY "default"
 
-typedef char *(*mako_format_func_t)(char variable, void *data);
+typedef char *(*mako_format_func_t)(char variable, bool *markup, void *data);
 
 bool hotspot_at(struct mako_hotspot *hotspot, int32_t x, int32_t y);
 
@@ -65,8 +65,8 @@ void close_notification(struct mako_notification *notif,
 	enum mako_notification_close_reason reason);
 void close_all_notifications(struct mako_state *state,
 	enum mako_notification_close_reason reason);
-char *format_state_text(char variable, void *data);
-char *format_notif_text(char variable, void *data);
+char *format_state_text(char variable, bool *markup, void *data);
+char *format_notif_text(char variable, bool *markup, void *data);
 size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data);
 struct mako_notification *get_notification(struct mako_state *state, uint32_t id);
 size_t format_notification(struct mako_notification *notif, const char *format,

--- a/include/notification.h
+++ b/include/notification.h
@@ -69,7 +69,7 @@ const char *format_state_text(char variable, void *data);
 const char *format_notif_text(char variable, void *data);
 size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data);
 struct mako_notification *get_notification(struct mako_state *state, uint32_t id);
-size_t format_notification(struct mako_state *state, struct mako_notification *notif, const char *format,
+size_t format_notification(struct mako_notification *notif, const char *format,
 		char *buf);
 void notification_handle_button(struct mako_notification *notif, uint32_t button,
 		enum wl_pointer_button_state state);

--- a/include/notification.h
+++ b/include/notification.h
@@ -55,7 +55,7 @@ enum mako_notification_close_reason {
 
 #define DEFAULT_ACTION_KEY "default"
 
-typedef const char *(*mako_format_func_t)(char variable, void *data);
+typedef char *(*mako_format_func_t)(char variable, void *data);
 
 bool hotspot_at(struct mako_hotspot *hotspot, int32_t x, int32_t y);
 

--- a/main.c
+++ b/main.c
@@ -28,6 +28,7 @@ static const char usage[] =
 	"      --border-color <color>      Border color.\n"
 	"      --markup <0|1>              Enable/disable markup.\n"
 	"      --format <format>           Format string.\n"
+	"      --hidden-format <format>    Format string.\n"
 	"      --max-visible <n>           Max number of visible notifications.\n"
 	"      --default-timeout <timeout> Default timeout in milliseconds.\n"
 	"      --output <name>             Show notifications on this output.\n"

--- a/notification.c
+++ b/notification.c
@@ -329,10 +329,10 @@ void notification_handle_button(struct mako_notification *notif, uint32_t button
 	case MAKO_BUTTON_BINDING_INVOKE_DEFAULT_ACTION:;
 		struct mako_action *action;
 		wl_list_for_each(action, &notif->actions, link) {
-		       if (strcmp(action->key, DEFAULT_ACTION_KEY) == 0) {
+			if (strcmp(action->key, DEFAULT_ACTION_KEY) == 0) {
 			       notify_action_invoked(action);
 			       break;
-		       }
+			}
 		}
 		close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
 		break;

--- a/notification.c
+++ b/notification.c
@@ -174,7 +174,7 @@ const char* format_notif_text(char variable, void *data) {
 	return value;
 }
 
-size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data) {
+size_t format_text(const char *format, char *buf, mako_format_func_t format_func, void *data) {
 	size_t len = 0;
 
 	const char *last = format;
@@ -201,7 +201,7 @@ size_t format_text(const char *format, char *buf, mako_format_func_t func, void 
 		if (current[1] == '%') { 
 			value = "%";
 		} else {
-			value =	func(current[1], data);
+			value =	format_func(current[1], data);
 		}
 		if (value == NULL) {
 			value = "";

--- a/notification.c
+++ b/notification.c
@@ -32,7 +32,7 @@ struct mako_notification *create_notification(struct mako_state *state) {
 	++state->last_id;
 	notif->id = state->last_id;
 	wl_list_init(&notif->actions);
-	notif->urgency = MAKO_NOTIFICATION_URGENCY_UNKNWON;
+	notif->urgency = MAKO_NOTIFICATION_URGENCY_UNKNOWN;
 	wl_list_insert(&state->notifications, &notif->link);
 	return notif;
 }
@@ -146,29 +146,28 @@ static char *notification_hidden_count(struct mako_state *state) {
 	return hidden_text;
 }
 
-const char *format_state_text(char variable, void *data) {
+char *format_state_text(char variable, void *data) {
 	struct mako_state *state = (struct mako_state *)data;
-	const char *value = NULL;
 	switch (variable) {
 	case 'h':
-		value = notification_hidden_count(state);
-		break;
+		return notification_hidden_count(state);
+	default:
+		return NULL;
 	}
-	return value;
 }
 
-const char* format_notif_text(char variable, void *data) {
+char* format_notif_text(char variable, void *data) {
 	struct mako_notification *notif = (struct mako_notification *)data;
 	char *value = NULL;
 	switch (variable) {
 	case 'a':
-		value = notif->app_name;
+		value = strdup(notif->app_name);
 		break;
 	case 's':
-		value = notif->summary; 
+		value = strdup(notif->summary); 
 		break;
 	case 'b':
-		value = notif->body;
+		value = strdup(notif->body);
 		break;
 	}
 	return value;
@@ -220,8 +219,9 @@ size_t format_text(const char *format, char *buf, mako_format_func_t format_func
 				memcpy(buf + len, value, value_len);
 			}
 		}
-		len += value_len;
+		free(value);
 
+		len += value_len;
 		last = current + 2;
 	}
 

--- a/notification.c
+++ b/notification.c
@@ -150,9 +150,9 @@ const char *format_state_text(char variable, void *data) {
 	struct mako_state *state = (struct mako_state *)data;
 	const char *value = NULL;
 	switch (variable) {
-		case 'h':
-			value = notification_hidden_count(state);
-			break;
+	case 'h':
+		value = notification_hidden_count(state);
+		break;
 	}
 	return value;
 }
@@ -161,15 +161,15 @@ const char* format_notif_text(char variable, void *data) {
 	struct mako_notification *notif = (struct mako_notification *)data;
 	char *value = NULL;
 	switch (variable) {
-		case 'a':
-			value = notif->app_name;
-			break;
-		case 's':
-			value = notif->summary; 
-			break;
-		case 'b':
-			value = notif->body;
-			break;
+	case 'a':
+		value = notif->app_name;
+		break;
+	case 's':
+		value = notif->summary; 
+		break;
+	case 'b':
+		value = notif->body;
+		break;
 	}
 	return value;
 }
@@ -256,19 +256,19 @@ size_t format_notification(struct mako_notification *notif, const char *format,
 		const char *value = NULL;
 		bool markup = false;
 		switch (current[1]) {
-			case '%':
-				value = "%";
-				break;
-			case 'a':
-				value = notif->app_name;
-				break;
-			case 's':
-				value = notif->summary;
-				break;
-			case 'b':
-				value = notif->body;
-				markup = true;
-				break;
+		case '%':
+			value = "%";
+			break;
+		case 'a':
+			value = notif->app_name;
+			break;
+		case 's':
+			value = notif->summary;
+			break;
+		case 'b':
+			value = notif->body;
+			markup = true;
+			break;
 		}
 		if (value == NULL) {
 			value = "";
@@ -301,12 +301,12 @@ size_t format_notification(struct mako_notification *notif, const char *format,
 static enum mako_button_binding get_button_binding(struct mako_config *config,
 		uint32_t button) {
 	switch (button) {
-		case BTN_LEFT:
-			return config->button_bindings.left;
-		case BTN_RIGHT:
-			return config->button_bindings.right;
-		case BTN_MIDDLE:
-			return config->button_bindings.middle;
+	case BTN_LEFT:
+		return config->button_bindings.left;
+	case BTN_RIGHT:
+		return config->button_bindings.right;
+	case BTN_MIDDLE:
+		return config->button_bindings.middle;
 	}
 	return MAKO_BUTTON_BINDING_NONE;
 }
@@ -318,23 +318,23 @@ void notification_handle_button(struct mako_notification *notif, uint32_t button
 	}
 
 	switch (get_button_binding(&notif->state->config, button)) {
-		case MAKO_BUTTON_BINDING_NONE:
-			break;
-		case MAKO_BUTTON_BINDING_DISMISS:
-			close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
-			break;
-		case MAKO_BUTTON_BINDING_DISMISS_ALL:
-			close_all_notifications(notif->state, MAKO_NOTIFICATION_CLOSE_DISMISSED);
-			break;
-		case MAKO_BUTTON_BINDING_INVOKE_DEFAULT_ACTION:;
-							       struct mako_action *action;
-							       wl_list_for_each(action, &notif->actions, link) {
-								       if (strcmp(action->key, DEFAULT_ACTION_KEY) == 0) {
-									       notify_action_invoked(action);
-									       break;
-								       }
-							       }
-							       close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
-							       break;
+	case MAKO_BUTTON_BINDING_NONE:
+		break;
+	case MAKO_BUTTON_BINDING_DISMISS:
+		close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+		break;
+	case MAKO_BUTTON_BINDING_DISMISS_ALL:
+		close_all_notifications(notif->state, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+		break;
+	case MAKO_BUTTON_BINDING_INVOKE_DEFAULT_ACTION:;
+		struct mako_action *action;
+		wl_list_for_each(action, &notif->actions, link) {
+		       if (strcmp(action->key, DEFAULT_ACTION_KEY) == 0) {
+			       notify_action_invoked(action);
+			       break;
+		       }
+		}
+		close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+		break;
 	}
 }

--- a/notification.c
+++ b/notification.c
@@ -161,7 +161,7 @@ static char *mako_asprintf(const char *fmt, ...) {
 	return text;
 }
 
-char *format_state_text(char variable, void *data) {
+char *format_state_text(char variable, bool *markup, void *data) {
 	struct mako_state *state = data;
 	switch (variable) {
 	case 'h':;
@@ -174,7 +174,7 @@ char *format_state_text(char variable, void *data) {
 	return NULL;
 }
 
-char *format_notif_text(char variable, void *data) {
+char *format_notif_text(char variable, bool *markup, void *data) {
 	struct mako_notification *notif = data;
 	switch (variable) {
 	case 'a':
@@ -182,6 +182,7 @@ char *format_notif_text(char variable, void *data) {
 	case 's':
 		return strdup(notif->summary);
 	case 'b':
+		*markup = true;
 		return strdup(notif->body);
 	}
 	return NULL;
@@ -212,16 +213,12 @@ size_t format_text(const char *format, char *buf, mako_format_func_t format_func
 		bool markup = false;
 
 		if (current[1] == '%') { 
-			value = "%";
+			value = strdup("%");
 		} else {
-			value =	format_func(current[1], data);
+			value =	format_func(current[1], &markup, data);
 		}
 		if (value == NULL) {
 			value = strdup("");
-		}
-
-		if (current[1] == 'b') {
-			markup = true;
 		}
 
 		size_t value_len;

--- a/notification.c
+++ b/notification.c
@@ -137,25 +137,30 @@ static size_t escape_markup(const char *s, char *buf) {
 	return len;
 }
 
-static char *notification_hidden_count(struct mako_state *state) {
-	int hidden = (wl_list_length(&state->notifications) -
-			state->config.max_visible);
-
-	size_t hidden_ln = snprintf(NULL, 0, "%d",  hidden);
-	char *hidden_text = malloc(hidden_ln + 1);
-	snprintf(hidden_text, hidden_ln + 1, "%d", hidden);
-
-	return hidden_text;
-}
-
 char *format_state_text(char variable, void *data) {
 	struct mako_state *state = (struct mako_state *)data;
+	char *value = NULL;
 	switch (variable) {
-	case 'h':
-		return notification_hidden_count(state);
-	default:
-		return NULL;
+	case 'h':;
+		int hidden = wl_list_length(&state->notifications) - state->config.max_visible;
+		size_t hidden_ln = snprintf(NULL, 0, "%d", hidden);
+		value = malloc(hidden_ln + 1);
+		if(!value) {
+			break;
+		}
+		snprintf(value, hidden_ln + 1, "%d", hidden);
+		return value;
+	case 't':;
+		int count = wl_list_length(&state->notifications);
+		size_t total_ln = snprintf(NULL, 0, "%d", count);
+		value = malloc(total_ln + 1);
+		if(!value) {
+			break;
+		}
+		snprintf(value, total_ln + 1, "%d", count);
+		return value;
 	}
+	return value;
 }
 
 char* format_notif_text(char variable, void *data) {

--- a/notification.c
+++ b/notification.c
@@ -1,6 +1,8 @@
+#define _POSIX_C_SOURCE 200809L
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <wayland-client.h>
 #ifdef __linux__
 #include <linux/input-event-codes.h>
@@ -139,7 +141,7 @@ static char *notification_hidden_count(struct mako_state *state) {
 	int hidden = (wl_list_length(&state->notifications) -
 			state->config.max_visible);
 
-	int hidden_ln = snprintf(NULL, 0, "%d",  hidden);
+	size_t hidden_ln = snprintf(NULL, 0, "%d",  hidden);
 	char *hidden_text = malloc(hidden_ln + 1);
 	snprintf(hidden_text, hidden_ln + 1, "%d", hidden);
 
@@ -194,7 +196,7 @@ size_t format_text(const char *format, char *buf, mako_format_func_t format_func
 		}
 		len += chunk_len;
 
-		const char *value = NULL;
+		char *value = NULL;
 		bool markup = false;
 
 		if (current[1] == '%') { 

--- a/notification.c
+++ b/notification.c
@@ -150,15 +150,9 @@ const char *format_state_text(char variable, void *data) {
 	struct mako_state *state = (struct mako_state *)data;
 	const char *value = NULL;
 	switch (variable) {
-<<<<<<< HEAD
 	case 'h':
 		value = notification_hidden_count(state);
 		break;
-=======
-		case 'h':
-			value = notification_hidden_count(state);
-			break;
->>>>>>> added generic format functions
 	}
 	return value;
 }
@@ -167,7 +161,6 @@ const char* format_notif_text(char variable, void *data) {
 	struct mako_notification *notif = (struct mako_notification *)data;
 	char *value = NULL;
 	switch (variable) {
-<<<<<<< HEAD
 	case 'a':
 		value = notif->app_name;
 		break;
@@ -177,26 +170,12 @@ const char* format_notif_text(char variable, void *data) {
 	case 'b':
 		value = notif->body;
 		break;
-=======
-		case 'a':
-			value = notif->app_name;
-			break;
-		case 's':
-			value = notif->summary; 
-			break;
-		case 'b':
-			value = notif->body;
-			break;
->>>>>>> added generic format functions
 	}
 	return value;
 }
 
 <<<<<<< HEAD
 size_t format_text(const char *format, char *buf, mako_format_func_t format_func, void *data) {
-=======
-size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data) {
->>>>>>> added generic format functions
 	size_t len = 0;
 
 	const char *last = format;
@@ -223,11 +202,7 @@ size_t format_text(const char *format, char *buf, mako_format_func_t func, void 
 		if (current[1] == '%') { 
 			value = "%";
 		} else {
-<<<<<<< HEAD
 			value =	format_func(current[1], data);
-=======
-			value =	func(current[1], data);
->>>>>>> added generic format functions
 		}
 		if (value == NULL) {
 			value = "";
@@ -257,12 +232,8 @@ size_t format_text(const char *format, char *buf, mako_format_func_t func, void 
 	return len;
 
 }
-<<<<<<< HEAD
-size_t format_notification(struct mako_notification *notif, const char *format,
-=======
-size_t format_notification(struct mako_state *state, struct mako_notification *notif, const char *format,
->>>>>>> added generic format functions
-		char *buf) {
+
+size_t format_notification(struct mako_notification *notif, const char *format, char *buf) {
 	size_t len = 0;
 
 	const char *last = format;

--- a/notification.c
+++ b/notification.c
@@ -231,7 +231,7 @@ size_t format_text(const char *format, char *buf, mako_format_func_t format_func
 	return len;
 
 }
-size_t format_notification(struct mako_state *state, struct mako_notification *notif, const char *format,
+size_t format_notification(struct mako_notification *notif, const char *format,
 		char *buf) {
 	size_t len = 0;
 
@@ -268,9 +268,6 @@ size_t format_notification(struct mako_state *state, struct mako_notification *n
 			case 'b':
 				value = notif->body;
 				markup = true;
-				break;
-			case 'h':
-				value = notification_hidden_count(state);
 				break;
 		}
 		if (value == NULL) {

--- a/notification.c
+++ b/notification.c
@@ -10,7 +10,6 @@
 
 #include "dbus.h"
 #include "event-loop.h"
-
 #include "mako.h"
 #include "notification.h"
 
@@ -175,7 +174,6 @@ const char* format_notif_text(char variable, void *data) {
 	return value;
 }
 
-<<<<<<< HEAD
 size_t format_text(const char *format, char *buf, mako_format_func_t format_func, void *data) {
 	size_t len = 0;
 

--- a/notification.c
+++ b/notification.c
@@ -138,7 +138,7 @@ static size_t escape_markup(const char *s, char *buf) {
 }
 
 char *format_state_text(char variable, void *data) {
-	struct mako_state *state = (struct mako_state *)data;
+	struct mako_state *state = data;
 	char *value = NULL;
 	switch (variable) {
 	case 'h':;
@@ -163,8 +163,8 @@ char *format_state_text(char variable, void *data) {
 	return value;
 }
 
-char* format_notif_text(char variable, void *data) {
-	struct mako_notification *notif = (struct mako_notification *)data;
+char *format_notif_text(char variable, void *data) {
+	struct mako_notification *notif = data;
 	char *value = NULL;
 	switch (variable) {
 	case 'a':
@@ -237,72 +237,6 @@ size_t format_text(const char *format, char *buf, mako_format_func_t format_func
 	}
 	return len;
 
-}
-
-size_t format_notification(struct mako_notification *notif, const char *format, char *buf) {
-	size_t len = 0;
-
-	const char *last = format;
-	while (1) {
-		char *current = strchr(last, '%');
-		if (current == NULL || current[1] == '\0') {
-			size_t tail_len = strlen(last);
-			if (buf != NULL) {
-				memcpy(buf + len, last, tail_len + 1);
-			}
-			len += tail_len;
-			break;
-		}
-
-		size_t chunk_len = current - last;
-		if (buf != NULL) {
-			memcpy(buf + len, last, chunk_len);
-		}
-		len += chunk_len;
-
-		const char *value = NULL;
-		bool markup = false;
-		switch (current[1]) {
-		case '%':
-			value = "%";
-			break;
-		case 'a':
-			value = notif->app_name;
-			break;
-		case 's':
-			value = notif->summary;
-			break;
-		case 'b':
-			value = notif->body;
-			markup = true;
-			break;
-		}
-		if (value == NULL) {
-			value = "";
-		}
-
-		size_t value_len;
-		if (!markup) {
-			char *escaped = NULL;
-			if (buf != NULL) {
-				escaped = buf + len;
-			}
-			value_len = escape_markup(value, escaped);
-		} else {
-			value_len = strlen(value);
-			if (buf != NULL) {
-				memcpy(buf + len, value, value_len);
-			}
-		}
-		len += value_len;
-
-		last = current + 2;
-	}
-
-	if (buf != NULL) {
-		trim_space(buf, buf);
-	}
-	return len;
 }
 
 static enum mako_button_binding get_button_binding(struct mako_config *config,

--- a/notification.c
+++ b/notification.c
@@ -9,6 +9,7 @@
 #endif
 
 #include "dbus.h"
+#include "event-loop.h"
 
 #include "mako.h"
 #include "notification.h"

--- a/notification.c
+++ b/notification.c
@@ -150,9 +150,15 @@ const char *format_state_text(char variable, void *data) {
 	struct mako_state *state = (struct mako_state *)data;
 	const char *value = NULL;
 	switch (variable) {
+<<<<<<< HEAD
 	case 'h':
 		value = notification_hidden_count(state);
 		break;
+=======
+		case 'h':
+			value = notification_hidden_count(state);
+			break;
+>>>>>>> added generic format functions
 	}
 	return value;
 }
@@ -161,6 +167,7 @@ const char* format_notif_text(char variable, void *data) {
 	struct mako_notification *notif = (struct mako_notification *)data;
 	char *value = NULL;
 	switch (variable) {
+<<<<<<< HEAD
 	case 'a':
 		value = notif->app_name;
 		break;
@@ -170,11 +177,26 @@ const char* format_notif_text(char variable, void *data) {
 	case 'b':
 		value = notif->body;
 		break;
+=======
+		case 'a':
+			value = notif->app_name;
+			break;
+		case 's':
+			value = notif->summary; 
+			break;
+		case 'b':
+			value = notif->body;
+			break;
+>>>>>>> added generic format functions
 	}
 	return value;
 }
 
+<<<<<<< HEAD
 size_t format_text(const char *format, char *buf, mako_format_func_t format_func, void *data) {
+=======
+size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data) {
+>>>>>>> added generic format functions
 	size_t len = 0;
 
 	const char *last = format;
@@ -201,7 +223,11 @@ size_t format_text(const char *format, char *buf, mako_format_func_t format_func
 		if (current[1] == '%') { 
 			value = "%";
 		} else {
+<<<<<<< HEAD
 			value =	format_func(current[1], data);
+=======
+			value =	func(current[1], data);
+>>>>>>> added generic format functions
 		}
 		if (value == NULL) {
 			value = "";
@@ -231,7 +257,11 @@ size_t format_text(const char *format, char *buf, mako_format_func_t format_func
 	return len;
 
 }
+<<<<<<< HEAD
 size_t format_notification(struct mako_notification *notif, const char *format,
+=======
+size_t format_notification(struct mako_state *state, struct mako_notification *notif, const char *format,
+>>>>>>> added generic format functions
 		char *buf) {
 	size_t len = 0;
 

--- a/notification.c
+++ b/notification.c
@@ -330,8 +330,8 @@ void notification_handle_button(struct mako_notification *notif, uint32_t button
 		struct mako_action *action;
 		wl_list_for_each(action, &notif->actions, link) {
 			if (strcmp(action->key, DEFAULT_ACTION_KEY) == 0) {
-			       notify_action_invoked(action);
-			       break;
+				notify_action_invoked(action);
+				break;
 			}
 		}
 		close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);

--- a/notification.c
+++ b/notification.c
@@ -135,7 +135,18 @@ static size_t escape_markup(const char *s, char *buf) {
 	return len;
 }
 
-size_t format_notification(struct mako_notification *notif, const char *format,
+static char *notification_hidden_count(struct mako_state *state) {
+	int hidden = (wl_list_length(&state->notifications) -
+			state->config.max_visible);
+
+	int hidden_ln = snprintf(NULL, 0, "%d",  hidden);
+	char *hidden_text = malloc(hidden_ln + 1);
+	snprintf(hidden_text, hidden_ln + 1, "%d", hidden);
+
+	return hidden_text;
+}
+
+size_t format_notification(struct mako_state *state, struct mako_notification *notif, const char *format,
 		char *buf) {
 	size_t len = 0;
 
@@ -160,19 +171,22 @@ size_t format_notification(struct mako_notification *notif, const char *format,
 		const char *value = NULL;
 		bool markup = false;
 		switch (current[1]) {
-		case '%':
-			value = "%";
-			break;
-		case 'a':
-			value = notif->app_name;
-			break;
-		case 's':
-			value = notif->summary;
-			break;
-		case 'b':
-			value = notif->body;
-			markup = true;
-			break;
+			case '%':
+				value = "%";
+				break;
+			case 'a':
+				value = notif->app_name;
+				break;
+			case 's':
+				value = notif->summary;
+				break;
+			case 'b':
+				value = notif->body;
+				markup = true;
+				break;
+			case 'h':
+				value = notification_hidden_count(state);
+				break;
 		}
 		if (value == NULL) {
 			value = "";
@@ -205,12 +219,12 @@ size_t format_notification(struct mako_notification *notif, const char *format,
 static enum mako_button_binding get_button_binding(struct mako_config *config,
 		uint32_t button) {
 	switch (button) {
-	case BTN_LEFT:
-		return config->button_bindings.left;
-	case BTN_RIGHT:
-		return config->button_bindings.right;
-	case BTN_MIDDLE:
-		return config->button_bindings.middle;
+		case BTN_LEFT:
+			return config->button_bindings.left;
+		case BTN_RIGHT:
+			return config->button_bindings.right;
+		case BTN_MIDDLE:
+			return config->button_bindings.middle;
 	}
 	return MAKO_BUTTON_BINDING_NONE;
 }
@@ -222,23 +236,23 @@ void notification_handle_button(struct mako_notification *notif, uint32_t button
 	}
 
 	switch (get_button_binding(&notif->state->config, button)) {
-	case MAKO_BUTTON_BINDING_NONE:
-		break;
-	case MAKO_BUTTON_BINDING_DISMISS:
-		close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
-		break;
-	case MAKO_BUTTON_BINDING_DISMISS_ALL:
-		close_all_notifications(notif->state, MAKO_NOTIFICATION_CLOSE_DISMISSED);
-		break;
-	case MAKO_BUTTON_BINDING_INVOKE_DEFAULT_ACTION:;
-		struct mako_action *action;
-		wl_list_for_each(action, &notif->actions, link) {
-			if (strcmp(action->key, DEFAULT_ACTION_KEY) == 0) {
-				notify_action_invoked(action);
-				break;
-			}
-		}
-		close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
-		break;
+		case MAKO_BUTTON_BINDING_NONE:
+			break;
+		case MAKO_BUTTON_BINDING_DISMISS:
+			close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+			break;
+		case MAKO_BUTTON_BINDING_DISMISS_ALL:
+			close_all_notifications(notif->state, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+			break;
+		case MAKO_BUTTON_BINDING_INVOKE_DEFAULT_ACTION:;
+							       struct mako_action *action;
+							       wl_list_for_each(action, &notif->actions, link) {
+								       if (strcmp(action->key, DEFAULT_ACTION_KEY) == 0) {
+									       notify_action_invoked(action);
+									       break;
+								       }
+							       }
+							       close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+							       break;
 	}
 }

--- a/notification.c
+++ b/notification.c
@@ -9,7 +9,7 @@
 #endif
 
 #include "dbus.h"
-#include "event-loop.h"
+
 #include "mako.h"
 #include "notification.h"
 

--- a/render.c
+++ b/render.c
@@ -167,14 +167,14 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 
 	if (wl_list_length(&state->notifications) > config->max_visible) {
 
-		height += inner_margin;
+		height += config->hidden_margin;
 
-		size_t hidden_ln = format_text("<b>%h hidden notifications..</b>", NULL, format_state_text, state);
+		size_t hidden_ln = format_text(config->hidden_format, NULL, format_state_text, state);
 		char *hidden_text = malloc(hidden_ln + 1);
 		if (hidden_text == NULL) {
 			return 0;
 		}
-		format_text("<b>%h hidden notifications..</b>", hidden_text, format_state_text, state);
+		format_text(config->hidden_format, hidden_text, format_state_text, state);
 
 		int hidden_height =
 			render_notification(cairo, state, hidden_text, height, scale);

--- a/render.c
+++ b/render.c
@@ -20,6 +20,7 @@ static void set_source_u32(cairo_t *cairo, uint32_t color) {
 		(color >> (0*8) & 0xFF) / 255.0);
 }
 
+<<<<<<< HEAD
 static void set_layout_size(PangoLayout *layout, int width, int height,
 		int scale) {
 	pango_layout_set_width(layout, width * scale * PANGO_SCALE);
@@ -37,6 +38,9 @@ static void set_rectangle(cairo_t *cairo, int x, int y, int width, int height,
 
 static int render_notification(cairo_t *cairo, struct mako_state *state,
 		const char *text, int offset_y, int scale) {
+=======
+static int render_notification(cairo_t *cairo, struct mako_state *state, struct mako_notification *notif, const char *text, int offset_y) {
+>>>>>>> added generic format functions
 	struct mako_config *config = &state->config;
 
 	int border_size = 2 * config->border_size;
@@ -53,7 +57,11 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	pango_layout_set_font_description(layout, desc);
 	pango_font_description_free(desc);
 
+<<<<<<< HEAD
 	PangoAttrList *attrs = NULL;
+=======
+
+>>>>>>> added generic format functions
 	if (config->markup) {
 		char *buf = NULL;
 		GError *error = NULL;
@@ -148,8 +156,14 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 			notif_y += inner_margin;
 		}
 
+<<<<<<< HEAD
 		int notif_height =
 			render_notification(cairo, state, text, notif_y, scale);
+=======
+		int notif_height = render_notification(cairo, state, notif, config->format, notif_y);
+		free(text);
+
+>>>>>>> added generic format functions
 		height = notif_y + notif_height;
 
 		// Update hotspot
@@ -167,6 +181,7 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 
 	if (wl_list_length(&state->notifications) > config->max_visible) {
 
+<<<<<<< HEAD
 		height += config->hidden_margin;
 
 		size_t hidden_ln = format_text(config->hidden_format, NULL, format_state_text, state);
@@ -180,6 +195,12 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 			render_notification(cairo, state, hidden_text, height, scale);
 
 		height += hidden_height;
+=======
+		height += inner_margin;
+		//int hidden_height = render_notification(cairo, state, NULL, "<b>%h hidden notifications..</b>", height);
+
+		//height += hidden_height;	
+>>>>>>> added generic format functions
 	}
 
 	return height;

--- a/render.c
+++ b/render.c
@@ -169,7 +169,7 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 
 	if (wl_list_length(&state->notifications) > config->max_visible) {
 
-		height += 3;
+		height += inner_margin;
 
 		size_t text_ln = format_text(config->hidden_format, NULL, format_state_text, state);
 		char *text = malloc(text_ln + 1);

--- a/render.c
+++ b/render.c
@@ -171,17 +171,17 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 
 		height += config->hidden_margin;
 
-		size_t hidden_ln = format_text(config->hidden_format, NULL, format_state_text, state);
-		char *hidden_text = malloc(hidden_ln + 1);
-		if (hidden_text == NULL) {
+		size_t text_ln = format_text(config->hidden_format, NULL, format_state_text, state);
+		char *text = malloc(text_ln + 1);
+		if (text == NULL) {
 			return height;
 		}
-		format_text(config->hidden_format, hidden_text, format_state_text, state);
+		format_text(config->hidden_format, text, format_state_text, state);
 
 		int hidden_height =
-			render_notification(cairo, state, hidden_text, height, scale);
+			render_notification(cairo, state, text, height, scale);
 
-		free(hidden_text);
+		free(text);
 
 		height += hidden_height;
 	}

--- a/render.c
+++ b/render.c
@@ -169,7 +169,7 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 
 	if (wl_list_length(&state->notifications) > config->max_visible) {
 
-		height += config->hidden_margin;
+		height += 3;
 
 		size_t text_ln = format_text(config->hidden_format, NULL, format_state_text, state);
 		char *text = malloc(text_ln + 1);

--- a/render.c
+++ b/render.c
@@ -180,7 +180,6 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 
 		int hidden_height =
 			render_notification(cairo, state, text, height, scale);
-
 		free(text);
 
 		height += hidden_height;

--- a/render.c
+++ b/render.c
@@ -139,7 +139,7 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 		size_t text_len = format_text(config->format, NULL, format_notif_text, notif);
 		char *text = malloc(text_len + 1);
 		if (text == NULL) {
-			return 0;
+			break;
 		}
 		format_text(config->format, text, format_notif_text, notif);
 
@@ -174,7 +174,7 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 		size_t hidden_ln = format_text(config->hidden_format, NULL, format_state_text, state);
 		char *hidden_text = malloc(hidden_ln + 1);
 		if (hidden_text == NULL) {
-			return 0;
+			return height;
 		}
 		format_text(config->hidden_format, hidden_text, format_state_text, state);
 

--- a/render.c
+++ b/render.c
@@ -118,7 +118,7 @@ int render(struct mako_state *state, struct pool_buffer *buffer) {
 			notif_y += inner_margin;
 		}
 
-		int notif_height = render_notification(cairo, state, notif, config->format, notif_y);
+		int notif_height = render_notification(cairo, state, notif, text, notif_y);
 		free(text);
 
 		height = notif_y + notif_height;
@@ -139,9 +139,17 @@ int render(struct mako_state *state, struct pool_buffer *buffer) {
 	if (wl_list_length(&state->notifications) > config->max_visible) {
 
 		height += inner_margin;
-		//int hidden_height = render_notification(cairo, state, NULL, "<b>%h hidden notifications..</b>", height);
 
-		//height += hidden_height;	
+		size_t text_len = format_text("<b>%h hidden notifications..</b>", NULL, format_state_text, state);
+		char *text = malloc(text_len + 1);
+		if (text == NULL) {
+			return 0;
+		}
+		format_text("<b>%h hidden notifications..</b>", text, format_state_text, state);
+
+		int hidden_height = render_notification(cairo, state, NULL, text, height);
+
+		height += hidden_height;	
 	}
 
 	return height;

--- a/render.c
+++ b/render.c
@@ -20,7 +20,6 @@ static void set_source_u32(cairo_t *cairo, uint32_t color) {
 		(color >> (0*8) & 0xFF) / 255.0);
 }
 
-<<<<<<< HEAD
 static void set_layout_size(PangoLayout *layout, int width, int height,
 		int scale) {
 	pango_layout_set_width(layout, width * scale * PANGO_SCALE);
@@ -38,9 +37,6 @@ static void set_rectangle(cairo_t *cairo, int x, int y, int width, int height,
 
 static int render_notification(cairo_t *cairo, struct mako_state *state,
 		const char *text, int offset_y, int scale) {
-=======
-static int render_notification(cairo_t *cairo, struct mako_state *state, struct mako_notification *notif, const char *text, int offset_y) {
->>>>>>> added generic format functions
 	struct mako_config *config = &state->config;
 
 	int border_size = 2 * config->border_size;
@@ -57,11 +53,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 	pango_layout_set_font_description(layout, desc);
 	pango_font_description_free(desc);
 
-<<<<<<< HEAD
 	PangoAttrList *attrs = NULL;
-=======
-
->>>>>>> added generic format functions
 	if (config->markup) {
 		char *buf = NULL;
 		GError *error = NULL;
@@ -156,14 +148,10 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 			notif_y += inner_margin;
 		}
 
-<<<<<<< HEAD
 		int notif_height =
 			render_notification(cairo, state, text, notif_y, scale);
-=======
-		int notif_height = render_notification(cairo, state, notif, config->format, notif_y);
 		free(text);
 
->>>>>>> added generic format functions
 		height = notif_y + notif_height;
 
 		// Update hotspot
@@ -181,7 +169,6 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 
 	if (wl_list_length(&state->notifications) > config->max_visible) {
 
-<<<<<<< HEAD
 		height += config->hidden_margin;
 
 		size_t hidden_ln = format_text(config->hidden_format, NULL, format_state_text, state);
@@ -194,13 +181,10 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 		int hidden_height =
 			render_notification(cairo, state, hidden_text, height, scale);
 
-		height += hidden_height;
-=======
-		height += inner_margin;
-		//int hidden_height = render_notification(cairo, state, NULL, "<b>%h hidden notifications..</b>", height);
+		free(hidden_text);
 
-		//height += hidden_height;	
->>>>>>> added generic format functions
+		height += hidden_height;
+
 	}
 
 	return height;

--- a/render.c
+++ b/render.c
@@ -184,7 +184,6 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 		free(hidden_text);
 
 		height += hidden_height;
-
 	}
 
 	return height;


### PR DESCRIPTION
I took your idea of the generic format functions and implemented `format_notif_text` and `format_state_text`. This would allow us to format strings based on state data and notification data. Next, I am going to work on adding something to the config so you can specify hidden notification format. 