### PR TITLE
Added priority sort options 

### DIFF
--- a/config.c
+++ b/config.c
@@ -180,16 +180,16 @@ static int apply_config_option(struct mako_config *config,
 	} else if (strcmp(name, "sort") == 0) {
 		if (strcmp(value, "+priority") == 0) {
 			config->sort_criteria |= MAKO_SORT_CRITERIA_URGENCY;
-			config->sort_asc |= MAKO_SORT_ASC_URGENCY;
+			config->sort_asc |= MAKO_SORT_CRITERIA_URGENCY;
 		} else if (strcmp(value, "-priority") == 0) {
 			config->sort_criteria |= MAKO_SORT_CRITERIA_URGENCY;
-			config->sort_asc &= ~MAKO_SORT_ASC_URGENCY;
+			config->sort_asc &= ~MAKO_SORT_CRITERIA_URGENCY;
 		} else if (strcmp(value, "+time") == 0) {
 			config->sort_criteria |= MAKO_SORT_CRITERIA_TIME;
-			config->sort_asc |= MAKO_SORT_ASC_TIME;
+			config->sort_asc |= MAKO_SORT_CRITERIA_TIME;
 		} else if (strcmp(value, "-time") == 0) {
 			config->sort_criteria |= MAKO_SORT_CRITERIA_TIME;
-			config->sort_asc &= ~MAKO_SORT_ASC_TIME;
+			config->sort_asc &= ~MAKO_SORT_CRITERIA_TIME;
 		}
 		return 0;
 	} else {
@@ -306,6 +306,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"hidden-format", required_argument, 0, 0},
 		{"max-visible", required_argument, 0, 0},
 		{"default-timeout", required_argument, 0, 0},
+		{"output", required_argument, 0, 0},
 		{"sort", required_argument, 0, 0},
 		{0},
 	};

--- a/config.c
+++ b/config.c
@@ -176,17 +176,14 @@ static int apply_config_option(struct mako_config *config,
 		free(config->output);
 		config->output = strdup(value);
 		return 0;
-	} else if (strcmp(name, "urgency") == 0) {
-		if (strcmp(value, "asc") == 0) {
+	} else if (strcmp(name, "sort") == 0) {
+		if (strcmp(value, "+priority") == 0) {
 			config->sort_direction |= (MAKO_SORT_DIRECTION_URGENCY | MAKO_SORT_DIRECTION_URGENCY_ASC);
-		} else if (strcmp(value, "des") == 0) {
+		} else if (strcmp(value, "-priority") == 0) {
 			config->sort_direction |= (MAKO_SORT_DIRECTION_URGENCY);
-		}
-		return 0;
-	} else if (strcmp(name, "time") == 0) {
-		if (strcmp(value, "asc") == 0) {
+		} else if (strcmp(value, "+time") == 0) {
 			config->sort_direction |= (MAKO_SORT_DIRECTION_TIME_ASC);
-		} else if (strcmp(value, "des") == 0) {
+		} else if (strcmp(value, "-time") == 0) {
 			config->sort_direction &= ~(MAKO_SORT_DIRECTION_URGENCY);
 		}
 		return 0;
@@ -304,9 +301,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"hidden-format", required_argument, 0, 0},
 		{"max-visible", required_argument, 0, 0},
 		{"default-timeout", required_argument, 0, 0},
-		{"output", required_argument, 0, 0},
-		{"urgency", required_argument, 0, 0},
-		{"time", required_argument, 0, 0},
+		{"sort", required_argument, 0, 0},
 		{0},
 	};
 

--- a/config.c
+++ b/config.c
@@ -21,7 +21,8 @@ void init_config(struct mako_config *config) {
 	config->format = strdup("<b>%s</b>\n%b");
 	config->hidden_format = strdup("%t[%h]");
 	config->actions = true;
-	config->sort_direction = 0;
+	config->sort_criteria = MAKO_SORT_CRITERIA_TIME;
+	config->sort_asc = 0;
 
 	config->margin.top = 10;
 	config->margin.right = 10;
@@ -178,13 +179,17 @@ static int apply_config_option(struct mako_config *config,
 		return 0;
 	} else if (strcmp(name, "sort") == 0) {
 		if (strcmp(value, "+priority") == 0) {
-			config->sort_direction |= (MAKO_SORT_DIRECTION_URGENCY | MAKO_SORT_DIRECTION_URGENCY_ASC);
+			config->sort_criteria |= MAKO_SORT_CRITERIA_URGENCY;
+			config->sort_asc |= MAKO_SORT_ASC_URGENCY;
 		} else if (strcmp(value, "-priority") == 0) {
-			config->sort_direction |= (MAKO_SORT_DIRECTION_URGENCY);
+			config->sort_criteria |= MAKO_SORT_CRITERIA_URGENCY;
+			config->sort_asc &= ~MAKO_SORT_ASC_URGENCY;
 		} else if (strcmp(value, "+time") == 0) {
-			config->sort_direction |= (MAKO_SORT_DIRECTION_TIME_ASC);
+			config->sort_criteria |= MAKO_SORT_CRITERIA_TIME;
+			config->sort_asc |= MAKO_SORT_ASC_TIME;
 		} else if (strcmp(value, "-time") == 0) {
-			config->sort_direction &= ~(MAKO_SORT_DIRECTION_URGENCY);
+			config->sort_criteria |= MAKO_SORT_CRITERIA_TIME;
+			config->sort_asc &= ~MAKO_SORT_ASC_TIME;
 		}
 		return 0;
 	} else {

--- a/config.c
+++ b/config.c
@@ -21,6 +21,7 @@ void init_config(struct mako_config *config) {
 	config->format = strdup("<b>%s</b>\n%b");
 	config->hidden_format = strdup("%t[%h]");
 	config->actions = true;
+	config->sort_direction = 0;
 
 	config->margin.top = 10;
 	config->margin.right = 10;
@@ -175,6 +176,20 @@ static int apply_config_option(struct mako_config *config,
 		free(config->output);
 		config->output = strdup(value);
 		return 0;
+	} else if (strcmp(name, "urgency") == 0) {
+		if (strcmp(value, "asc") == 0) {
+			config->sort_direction |= (MAKO_SORT_DIRECTION_URGENCY | MAKO_SORT_DIRECTION_URGENCY_ASC);
+		} else if (strcmp(value, "des") == 0) {
+			config->sort_direction |= (MAKO_SORT_DIRECTION_URGENCY);
+		}
+		return 0;
+	} else if (strcmp(name, "time") == 0) {
+		if (strcmp(value, "asc") == 0) {
+			config->sort_direction |= (MAKO_SORT_DIRECTION_TIME_ASC);
+		} else if (strcmp(value, "des") == 0) {
+			config->sort_direction &= ~(MAKO_SORT_DIRECTION_URGENCY);
+		}
+		return 0;
 	} else {
 		return 1;
 	}
@@ -290,6 +305,8 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"max-visible", required_argument, 0, 0},
 		{"default-timeout", required_argument, 0, 0},
 		{"output", required_argument, 0, 0},
+		{"urgency", required_argument, 0, 0},
+		{"time", required_argument, 0, 0},
 		{0},
 	};
 

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -215,6 +215,8 @@ static int handle_notify(sd_bus_message *msg, void *data,
 	if (expire_timeout < 0) {
 		expire_timeout = state->config.default_timeout;
 	}
+
+	insert_notification(state, notif);
 	if (expire_timeout > 0) {
 		notif->timer = add_event_loop_timer(&state->event_loop, expire_timeout,
 			handle_notification_timer, notif);

--- a/include/config.h
+++ b/include/config.h
@@ -23,11 +23,6 @@ enum mako_sort_criteria {
 	MAKO_SORT_CRITERIA_URGENCY = 2,
 };
 
-enum mako_sort_asc {
-	MAKO_SORT_ASC_TIME = 1,
-	MAKO_SORT_ASC_URGENCY = 2,
-};
-
 struct mako_config {
 	char *font;
 	int32_t width, height;
@@ -40,8 +35,8 @@ struct mako_config {
 	int32_t max_visible;
 	char *output;
 	char *hidden_format;
-	enum mako_sort_criteria sort_criteria;
-	enum mako_sort_asc sort_asc;
+	uint32_t sort_criteria; //enum mako_sort_criteria
+	uint32_t sort_asc;
 
 	int default_timeout; // in ms
 

--- a/include/config.h
+++ b/include/config.h
@@ -18,10 +18,14 @@ enum mako_button_binding {
 	MAKO_BUTTON_BINDING_INVOKE_DEFAULT_ACTION,
 };
 
-enum mako_sort_direction {
-	MAKO_SORT_DIRECTION_TIME_ASC = 1,
-	MAKO_SORT_DIRECTION_URGENCY_ASC = 2,
-	MAKO_SORT_DIRECTION_URGENCY = 4,
+enum mako_sort_criteria {
+	MAKO_SORT_CRITERIA_TIME = 1,
+	MAKO_SORT_CRITERIA_URGENCY = 2,
+};
+
+enum mako_sort_asc {
+	MAKO_SORT_ASC_TIME = 1,
+	MAKO_SORT_ASC_URGENCY = 2,
 };
 
 struct mako_config {
@@ -36,7 +40,8 @@ struct mako_config {
 	int32_t max_visible;
 	char *output;
 	char *hidden_format;
-	uint32_t sort_direction;
+	enum mako_sort_criteria sort_criteria;
+	enum mako_sort_asc sort_asc;
 
 	int default_timeout; // in ms
 

--- a/include/config.h
+++ b/include/config.h
@@ -18,6 +18,12 @@ enum mako_button_binding {
 	MAKO_BUTTON_BINDING_INVOKE_DEFAULT_ACTION,
 };
 
+enum mako_sort_direction {
+	MAKO_SORT_DIRECTION_TIME_ASC = 1,
+	MAKO_SORT_DIRECTION_URGENCY_ASC = 2,
+	MAKO_SORT_DIRECTION_URGENCY = 4,
+};
+
 struct mako_config {
 	char *font;
 	int32_t width, height;
@@ -30,6 +36,7 @@ struct mako_config {
 	int32_t max_visible;
 	char *output;
 	char *hidden_format;
+	uint32_t sort_direction;
 
 	int default_timeout; // in ms
 

--- a/include/notification.h
+++ b/include/notification.h
@@ -73,5 +73,5 @@ size_t format_notification(struct mako_notification *notif, const char *format,
 	char *buf);
 void notification_handle_button(struct mako_notification *notif, uint32_t button,
 	enum wl_pointer_button_state state);
-
+void insert_notification(struct mako_state *state, struct mako_notification *notif);
 #endif

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -85,6 +85,13 @@ dismissed with a click or via *makoctl*(1).
 
 	Default: 5
 
+*--sort* _+/-time_ | _+/-priority_
+	Sorts incoming notifications by time and/or priority in ascending(+)
+	or descending(-) order.
+
+	Default: -time
+
+
 *--default-timeout* _timeout_
 	Set the default timeout to _timeout_ in milliseconds. To disable the
 	timeout, set it to zero.

--- a/notification.c
+++ b/notification.c
@@ -288,7 +288,8 @@ void notification_handle_button(struct mako_notification *notif, uint32_t button
 }
 
 /*
- * Searches through the notifications list and returns the next position at which to insert based on urgency and direction
+ * Searches through the notifications list and returns the next position at which to insert.
+ * If no results for the specified urgency are found, it will return the closest link searching in the direction specifed. (-1 for lower, 1 or upper).
  */
 static struct wl_list *get_last_notif_by_urgency(struct wl_list *notifications, enum mako_notification_urgency urgency, int direction) {
 	enum mako_notification_urgency current = urgency;

--- a/notification.c
+++ b/notification.c
@@ -315,18 +315,21 @@ void insert_notification(struct mako_state *state, struct mako_notification *not
 	struct mako_config *config = &state->config;
 	struct wl_list *insert_node;
 
-	//This works but I don't like the way it's done. Can probably use some work.
-	if (config->sort_direction == 0x0) {
+	if (config->sort_criteria == MAKO_SORT_CRITERIA_TIME &&
+			!config->sort_asc) {
 		insert_node = &state->notifications;
-	} else if (config->sort_direction == 0x1) {
-		insert_node = state->notifications.prev;
-	} else if(config->sort_direction & MAKO_SORT_DIRECTION_URGENCY) {
-		int direction = (config->sort_direction & MAKO_SORT_DIRECTION_URGENCY_ASC) ? -1 : 1;
+	} else if (config->sort_criteria == MAKO_SORT_CRITERIA_TIME &&
+			(config->sort_asc & MAKO_SORT_ASC_TIME)) {
+			insert_node = state->notifications.prev;
+	} else if (config->sort_criteria & MAKO_SORT_CRITERIA_URGENCY) {
+		int direction = (config->sort_asc & MAKO_SORT_ASC_URGENCY) ? -1 : 1;
 		int offset = 0;
-		if (!(config->sort_direction & MAKO_SORT_DIRECTION_TIME_ASC)) {
+		if (!(config->sort_asc & MAKO_SORT_ASC_TIME)) {
 			offset = direction;
 		}
 		insert_node = get_last_notif_by_urgency(&state->notifications, notif->urgency + offset, direction);
+	} else {
+		insert_node = &state->notifications;
 	}
 
 	wl_list_insert(insert_node, &notif->link);

--- a/notification.c
+++ b/notification.c
@@ -324,7 +324,7 @@ void insert_notification(struct mako_state *state, struct mako_notification *not
 		insert_node = &state->notifications;
 	} else if (config->sort_criteria == MAKO_SORT_CRITERIA_TIME &&
 			(config->sort_asc & MAKO_SORT_CRITERIA_TIME)) {
-		insert_node = &state->notifications;
+		insert_node = state->notifications.prev;
 	} else if (config->sort_criteria & MAKO_SORT_CRITERIA_URGENCY) {
 		int direction = (config->sort_asc & MAKO_SORT_CRITERIA_URGENCY) ? -1 : 1;
 		int offset = 0;

--- a/notification.c
+++ b/notification.c
@@ -288,17 +288,21 @@ void notification_handle_button(struct mako_notification *notif, uint32_t button
 }
 
 /*
- * Searches through the notifications list and returns the next position at which to insert.
- * If no results for the specified urgency are found, it will return the closest link searching in the direction specifed. (-1 for lower, 1 or upper).
+ * Searches through the notifications list and returns the next position at
+ * which to insert. If no results for the specified urgency are found,
+ * it will return the closest link searching in the direction specifed.
+ * (-1 for lower, 1 or upper).
  */
-static struct wl_list *get_last_notif_by_urgency(struct wl_list *notifications, enum mako_notification_urgency urgency, int direction) {
+static struct wl_list *get_last_notif_by_urgency(struct wl_list *notifications,
+		enum mako_notification_urgency urgency, int direction) {
 	enum mako_notification_urgency current = urgency;
 
-	if (wl_list_length(notifications) == 0) {
+	if (wl_list_empty(notifications)) {
 		return notifications;
 	}
 
-	while (current <= MAKO_NOTIFICATION_URGENCY_HIGH && current >= MAKO_NOTIFICATION_URGENCY_UNKNOWN) {
+	while (current <= MAKO_NOTIFICATION_URGENCY_HIGH &&
+		current >= MAKO_NOTIFICATION_URGENCY_UNKNOWN) {
 		struct mako_notification *notif;
 		wl_list_for_each_reverse(notif, notifications, link) {
 			if (notif->urgency == current) {
@@ -316,18 +320,19 @@ void insert_notification(struct mako_state *state, struct mako_notification *not
 	struct wl_list *insert_node;
 
 	if (config->sort_criteria == MAKO_SORT_CRITERIA_TIME &&
-			!config->sort_asc) {
+			!(config->sort_asc & MAKO_SORT_CRITERIA_TIME)) {
 		insert_node = &state->notifications;
 	} else if (config->sort_criteria == MAKO_SORT_CRITERIA_TIME &&
-			(config->sort_asc & MAKO_SORT_ASC_TIME)) {
-			insert_node = state->notifications.prev;
+			(config->sort_asc & MAKO_SORT_CRITERIA_TIME)) {
+		insert_node = state->notifications.prev;
 	} else if (config->sort_criteria & MAKO_SORT_CRITERIA_URGENCY) {
-		int direction = (config->sort_asc & MAKO_SORT_ASC_URGENCY) ? -1 : 1;
+		int direction = (config->sort_asc & MAKO_SORT_CRITERIA_URGENCY) ? -1 : 1;
 		int offset = 0;
-		if (!(config->sort_asc & MAKO_SORT_ASC_TIME)) {
+		if (!(config->sort_asc & MAKO_SORT_CRITERIA_TIME)) {
 			offset = direction;
 		}
-		insert_node = get_last_notif_by_urgency(&state->notifications, notif->urgency + offset, direction);
+		insert_node = get_last_notif_by_urgency(&state->notifications,
+			notif->urgency + offset, direction);
 	} else {
 		insert_node = &state->notifications;
 	}

--- a/render.c
+++ b/render.c
@@ -56,8 +56,10 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	PangoAttrList *attrs = NULL;
 	if (config->markup) {
 		GError *error = NULL;
-		if (pango_parse_markup(text, -1, 0, &attrs, NULL, NULL, &error)) {
-			pango_layout_set_markup(layout, text, -1);
+		char *buf = NULL;
+		if (pango_parse_markup(text, -1, 0, &attrs, &buf, NULL, &error)) {
+			pango_layout_set_text(layout, buf, -1);
+			free(buf);
 		} else {
 			fprintf(stderr, "cannot parse pango markup: %s\n", error->message);
 			g_error_free(error);


### PR DESCRIPTION
Test it out with: 
```
./build/mako --max-visible 11 --sort +time --sort -priority
```

then to test, you can run the following and see how they get inserted: 
```
 for i in {1..10}; do  \
  URGENCY="";         \
  if [ $((i % 3)) -eq 0 ]; then \
    URGENCY="CRITICAL"; \
  elif [ $((i % 2)) -eq 0 ]; then \
    URGENCY="NORMAL";  \
  else \
    URGENCY="LOW"; \
  fi; \
  eval "notify-send -u $URGENCY -a \"test\" \"$URGENCY - $i\""; \
  sleep 0.5; \
done
```