### PR TITLE
Split notification style from config

### DIFF
--- a/config.c
+++ b/config.c
@@ -55,23 +55,7 @@ void init_default_style(struct mako_style *style) {
 	style->colors.border = 0x4C7899FF;
 
 	// Everything in the default config is explicitly specified.
-	style->spec = (struct mako_style_spec){
-		.width = true,
-		.height = true,
-		.margin = true,
-		.padding = true,
-		.border_size = true,
-		.font = true,
-		.markup = true,
-		.format = true,
-		.actions = true,
-		.default_timeout = true,
-		.colors = {
-			.background = true,
-			.text = true,
-			.border = true,
-		},
-	};
+	memset(&style->spec, true, sizeof(struct mako_style_spec));
 }
 
 void finish_style(struct mako_style *style) {

--- a/config.c
+++ b/config.c
@@ -167,53 +167,9 @@ static bool parse_color(const char *color, uint32_t *out) {
 
 static bool apply_config_option(struct mako_config *config, const char *section,
 		const char *name, const char *value) {
-	if (section != NULL) {
-		// TODO: criteria support
-		if (strcmp(section, "hidden") != 0) {
-			return false;
-		}
-
-		if (strcmp(name, "format") == 0) {
-			free(config->hidden_format);
-			config->hidden_format = strdup(value);
-			return true;
-		} else {
-			fprintf(stderr, "Only 'format' is supported in the 'hidden' section");
-			return false;
-		}
-	}
-
-	if (strcmp(name, "font") == 0) {
-		free(config->font);
-		config->font = strdup(value);
-		return true;
-	} else if (strcmp(name, "background-color") == 0) {
-		return parse_color(value, &config->colors.background);
-	} else if (strcmp(name, "text-color") == 0) {
-		return parse_color(value, &config->colors.text);
-	} else if (strcmp(name, "width") == 0) {
-		return parse_int(value, &config->width);
-	} else if (strcmp(name, "height") == 0) {
-		return parse_int(value, &config->height);
-	} else if (strcmp(name, "margin") == 0) {
-		return parse_directional(value, &config->margin);
-	} else if (strcmp(name, "padding") == 0) {
-		return parse_int(value, &config->padding);
-	} else if (strcmp(name, "border-size") == 0) {
-		return parse_int(value, &config->border_size);
-	} else if (strcmp(name, "border-color") == 0) {
-		return parse_color(value, &config->colors.border);
-	} else if (strcmp(name, "markup") == 0) {
-		config->markup = strcmp(value, "1") == 0;
-		return config->markup || strcmp(value, "0") == 0;
-	} else if (strcmp(name, "format") == 0) {
-		free(config->format);
-		config->format = strdup(value);
-		return true;
-	} else if (strcmp(name, "max-visible") == 0) {
+	// First try to parse this as a global option.
+	if (strcmp(name, "max-visible") == 0) {
 		return parse_int(value, &config->max_visible);
-	} else if (strcmp(name, "default-timeout") == 0) {
-		return parse_int(value, &config->default_timeout);
 	} else if (strcmp(name, "output") == 0) {
 		free(config->output);
 		config->output = strdup(value);
@@ -233,6 +189,55 @@ static bool apply_config_option(struct mako_config *config, const char *section,
 			config->sort_asc &= ~MAKO_SORT_CRITERIA_TIME;
 		}
 		return true;
+	} else if (section != NULL) {
+		// TODO: criteria support
+		if (strcmp(section, "hidden") != 0) {
+			fprintf(stderr, "Only the 'hidden' section is currently supported\n");
+			return false;
+		}
+
+		if (strcmp(name, "format") == 0) {
+			free(config->hidden_format);
+			config->hidden_format = strdup(value);
+			return true;
+		} else {
+			fprintf(stderr, "Only 'format' is supported in the 'hidden' section\n");
+			return false;
+		}
+	}
+
+	// Now try to match on style options.
+	struct mako_style *style = &config->default_style;
+
+	if (strcmp(name, "font") == 0) {
+		free(style->font);
+		style->font = strdup(value);
+		return true;
+	} else if (strcmp(name, "background-color") == 0) {
+		return parse_color(value, &style->colors.background);
+	} else if (strcmp(name, "text-color") == 0) {
+		return parse_color(value, &style->colors.text);
+	} else if (strcmp(name, "width") == 0) {
+		return parse_int(value, &style->width);
+	} else if (strcmp(name, "height") == 0) {
+		return parse_int(value, &style->height);
+	} else if (strcmp(name, "margin") == 0) {
+		return parse_directional(value, &style->margin);
+	} else if (strcmp(name, "padding") == 0) {
+		return parse_int(value, &style->padding);
+	} else if (strcmp(name, "border-size") == 0) {
+		return parse_int(value, &style->border_size);
+	} else if (strcmp(name, "border-color") == 0) {
+		return parse_color(value, &style->colors.border);
+	} else if (strcmp(name, "markup") == 0) {
+		style->markup = strcmp(value, "1") == 0;
+		return style->markup || strcmp(value, "0") == 0;
+	} else if (strcmp(name, "format") == 0) {
+		free(style->format);
+		style->format = strdup(value);
+		return true;
+	} else if (strcmp(name, "default-timeout") == 0) {
+		return parse_int(value, &style->default_timeout);
 	} else {
 		return false;
 	}

--- a/config.c
+++ b/config.c
@@ -11,40 +11,72 @@
 #include "config.h"
 
 void init_config(struct mako_config *config) {
-	config->font = strdup("monospace 10");
+	init_default_style(&config->default_style);
 
-	config->padding = 5;
-	config->width = 300;
-	config->height = 100;
-	config->border_size = 2;
-	config->markup = true;
-	config->format = strdup("<b>%s</b>\n%b");
 	config->hidden_format = strdup("(%h more)");
-	config->actions = true;
+	config->output = strdup("");
+	config->max_visible = 5;
+
 	config->sort_criteria = MAKO_SORT_CRITERIA_TIME;
 	config->sort_asc = 0;
 
-	config->margin.top = 10;
-	config->margin.right = 10;
-	config->margin.bottom = 10;
-	config->margin.left = 10;
-
-	config->max_visible = 5;
-	config->output = strdup("");
-
-	config->colors.background = 0x285577FF;
-	config->colors.text = 0xFFFFFFFF;
-	config->colors.border = 0x4C7899FF;
 	config->button_bindings.left = MAKO_BUTTON_BINDING_INVOKE_DEFAULT_ACTION;
 	config->button_bindings.right = MAKO_BUTTON_BINDING_DISMISS;
 	config->button_bindings.middle = MAKO_BUTTON_BINDING_NONE;
 }
 
 void finish_config(struct mako_config *config) {
-	free(config->font);
-	free(config->format);
+	finish_style(&config->default_style);
 	free(config->hidden_format);
 	free(config->output);
+}
+
+void init_default_style(struct mako_style *style) {
+	style->width = 300;
+	style->height = 100;
+
+	style->margin.top = 10;
+	style->margin.right = 10;
+	style->margin.bottom = 10;
+	style->margin.left = 10;
+
+	style->padding = 5;
+	style->border_size = 2;
+
+	style->font = strdup("monospace 10");
+	style->markup = true;
+	style->format = strdup("<b>%s</b>\n%b");
+
+	style->actions = true;
+	style->default_timeout = 0;
+
+	style->colors.background = 0x285577FF;
+	style->colors.text = 0xFFFFFFFF;
+	style->colors.border = 0x4C7899FF;
+
+	// Everything in the default config is explicitly specified.
+	style->spec = (struct mako_style_spec){
+		.width = true,
+		.height = true,
+		.margin = true,
+		.padding = true,
+		.border_size = true,
+		.font = true,
+		.markup = true,
+		.format = true,
+		.actions = true,
+		.default_timeout = true,
+		.colors = {
+			.background = true,
+			.text = true,
+			.border = true,
+		},
+	};
+}
+
+void finish_style(struct mako_style *style) {
+	free(style->font);
+	free(style->format);
 }
 
 static bool parse_int(const char *s, int *out) {

--- a/config.c
+++ b/config.c
@@ -10,7 +10,7 @@
 
 #include "config.h"
 
-void init_config(struct mako_config *config) {
+void init_default_config(struct mako_config *config) {
 	init_default_style(&config->style);
 
 	config->hidden_format = strdup("(%h more)");
@@ -383,7 +383,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 
 void reload_config(struct mako_config *config) {
 	finish_config(config);
-	init_config(config);
+	init_default_config(config);
 	load_config_file(config);
 	parse_config_arguments(config, config_argc, config_argv);
 }

--- a/config.c
+++ b/config.c
@@ -11,7 +11,7 @@
 #include "config.h"
 
 void init_config(struct mako_config *config) {
-	init_default_style(&config->default_style);
+	init_default_style(&config->style);
 
 	config->hidden_format = strdup("(%h more)");
 	config->output = strdup("");
@@ -26,7 +26,7 @@ void init_config(struct mako_config *config) {
 }
 
 void finish_config(struct mako_config *config) {
-	finish_style(&config->default_style);
+	finish_style(&config->style);
 	free(config->hidden_format);
 	free(config->output);
 }
@@ -207,7 +207,7 @@ static bool apply_config_option(struct mako_config *config, const char *section,
 	}
 
 	// Now try to match on style options.
-	struct mako_style *style = &config->default_style;
+	struct mako_style *style = &config->style;
 
 	if (strcmp(name, "font") == 0) {
 		free(style->font);

--- a/config.c
+++ b/config.c
@@ -152,28 +152,32 @@ static bool parse_color(const char *color, uint32_t *out) {
 static bool apply_config_option(struct mako_config *config, const char *section,
 		const char *name, const char *value) {
 	// First try to parse this as a global option.
-	if (strcmp(name, "max-visible") == 0) {
-		return parse_int(value, &config->max_visible);
-	} else if (strcmp(name, "output") == 0) {
-		free(config->output);
-		config->output = strdup(value);
-		return true;
-	} else if (strcmp(name, "sort") == 0) {
-		if (strcmp(value, "+priority") == 0) {
-			config->sort_criteria |= MAKO_SORT_CRITERIA_URGENCY;
-			config->sort_asc |= MAKO_SORT_CRITERIA_URGENCY;
-		} else if (strcmp(value, "-priority") == 0) {
-			config->sort_criteria |= MAKO_SORT_CRITERIA_URGENCY;
-			config->sort_asc &= ~MAKO_SORT_CRITERIA_URGENCY;
-		} else if (strcmp(value, "+time") == 0) {
-			config->sort_criteria |= MAKO_SORT_CRITERIA_TIME;
-			config->sort_asc |= MAKO_SORT_CRITERIA_TIME;
-		} else if (strcmp(value, "-time") == 0) {
-			config->sort_criteria |= MAKO_SORT_CRITERIA_TIME;
-			config->sort_asc &= ~MAKO_SORT_CRITERIA_TIME;
+	if (section == NULL) {
+		if (strcmp(name, "max-visible") == 0) {
+			return parse_int(value, &config->max_visible);
+		} else if (strcmp(name, "output") == 0) {
+			free(config->output);
+			config->output = strdup(value);
+			return true;
+		} else if (strcmp(name, "sort") == 0) {
+			if (strcmp(value, "+priority") == 0) {
+				config->sort_criteria |= MAKO_SORT_CRITERIA_URGENCY;
+				config->sort_asc |= MAKO_SORT_CRITERIA_URGENCY;
+			} else if (strcmp(value, "-priority") == 0) {
+				config->sort_criteria |= MAKO_SORT_CRITERIA_URGENCY;
+				config->sort_asc &= ~MAKO_SORT_CRITERIA_URGENCY;
+			} else if (strcmp(value, "+time") == 0) {
+				config->sort_criteria |= MAKO_SORT_CRITERIA_TIME;
+				config->sort_asc |= MAKO_SORT_CRITERIA_TIME;
+			} else if (strcmp(value, "-time") == 0) {
+				config->sort_criteria |= MAKO_SORT_CRITERIA_TIME;
+				config->sort_asc &= ~MAKO_SORT_CRITERIA_TIME;
+			}
+			return true;
+		} else {
+			// We want to try the style options now, so keep going.
 		}
-		return true;
-	} else if (section != NULL) {
+	} else {
 		// TODO: criteria support
 		if (strcmp(section, "hidden") != 0) {
 			fprintf(stderr, "Only the 'hidden' section is currently supported\n");

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -27,21 +27,21 @@ static int handle_get_capabilities(sd_bus_message *msg, void *data,
 		return ret;
 	}
 
-	if (strstr(state->config.format, "%b") != NULL) {
+	if (strstr(state->config.style.format, "%b") != NULL) {
 		ret = sd_bus_message_append(reply, "s", "body");
 		if (ret < 0) {
 			return ret;
 		}
 	}
 
-	if (state->config.markup) {
+	if (state->config.style.markup) {
 		ret = sd_bus_message_append(reply, "s", "body-markup");
 		if (ret < 0) {
 			return ret;
 		}
 	}
 
-	if (state->config.actions) {
+	if (state->config.style.actions) {
 		ret = sd_bus_message_append(reply, "s", "actions");
 		if (ret < 0) {
 			return ret;
@@ -213,7 +213,7 @@ static int handle_notify(sd_bus_message *msg, void *data,
 	}
 
 	if (expire_timeout < 0) {
-		expire_timeout = state->config.default_timeout;
+		expire_timeout = state->config.style.default_timeout;
 	}
 
 	insert_notification(state, notif);

--- a/include/config.h
+++ b/include/config.h
@@ -23,21 +23,33 @@ enum mako_sort_criteria {
 	MAKO_SORT_CRITERIA_URGENCY = 2,
 };
 
-struct mako_config {
-	char *font;
-	int32_t width, height;
+// Represents which fields in the style were specified in this style. Those
+// which are unspecified should fall through to the default style. All fields
+// in the mako_style structure should have a counterpart here. Inline structs
+// are also mirrored.
+struct mako_style_spec {
+	bool width, height, margin, padding, border_size, font, markup, format,
+		 actions, default_timeout;
+
+	struct {
+		bool background, text, border;
+	} colors;
+};
+
+struct mako_style {
+	struct mako_style_spec spec;
+
+	int32_t width;
+	int32_t height;
+	struct mako_directional margin;
 	int32_t padding;
 	int32_t border_size;
+
+	char *font;
 	bool markup;
 	char *format;
-	bool actions;
-	struct mako_directional margin;
-	int32_t max_visible;
-	char *output;
-	char *hidden_format;
-	uint32_t sort_criteria; //enum mako_sort_criteria
-	uint32_t sort_asc;
 
+	bool actions;
 	int default_timeout; // in ms
 
 	struct {
@@ -45,6 +57,16 @@ struct mako_config {
 		uint32_t text;
 		uint32_t border;
 	} colors;
+};
+
+struct mako_config {
+	struct mako_style default_style;
+
+	int32_t max_visible;
+	char *output;
+	char *hidden_format;
+	uint32_t sort_criteria; //enum mako_sort_criteria
+	uint32_t sort_asc;
 
 	struct {
 		enum mako_button_binding left, right, middle;
@@ -53,6 +75,10 @@ struct mako_config {
 
 void init_config(struct mako_config *config);
 void finish_config(struct mako_config *config);
+
+void init_default_style(struct mako_style *style);
+void finish_style(struct mako_style *style);
+
 int parse_config_arguments(struct mako_config *config, int argc, char **argv);
 int load_config_file(struct mako_config *config);
 void reload_config(struct mako_config *config);

--- a/include/config.h
+++ b/include/config.h
@@ -60,7 +60,7 @@ struct mako_style {
 };
 
 struct mako_config {
-	struct mako_style default_style;
+	struct mako_style style;
 
 	int32_t max_visible;
 	char *output;

--- a/include/config.h
+++ b/include/config.h
@@ -23,10 +23,9 @@ enum mako_sort_criteria {
 	MAKO_SORT_CRITERIA_URGENCY = 2,
 };
 
-// Represents which fields in the style were specified in this style. Those
-// which are unspecified should fall through to the default style. All fields
-// in the mako_style structure should have a counterpart here. Inline structs
-// are also mirrored.
+// Represents which fields in the style were specified in this style. All
+// fields in the mako_style structure should have a counterpart here. Inline
+// structs are also mirrored.
 struct mako_style_spec {
 	bool width, height, margin, padding, border_size, font, markup, format,
 		 actions, default_timeout;

--- a/include/config.h
+++ b/include/config.h
@@ -72,7 +72,7 @@ struct mako_config {
 	} button_bindings;
 };
 
-void init_config(struct mako_config *config);
+void init_default_config(struct mako_config *config);
 void finish_config(struct mako_config *config);
 
 void init_default_style(struct mako_style *style);

--- a/main.c
+++ b/main.c
@@ -67,7 +67,7 @@ static void handle_signal(int signum) {
 int main(int argc, char *argv[]) {
 	struct mako_state state = {0};
 
-	init_config(&state.config);
+	init_default_config(&state.config);
 
 	int ret = load_config_file(&state.config);
 	if (ret < 0) {

--- a/render.c
+++ b/render.c
@@ -114,6 +114,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 
 int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 	struct mako_config *config = &state->config;
+	struct mako_style *style = &config->default_style;
 	cairo_t *cairo = buffer->cairo;
 
 	if (wl_list_empty(&state->notifications)) {
@@ -127,9 +128,9 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 	cairo_paint(cairo);
 	cairo_restore(cairo);
 
-	int inner_margin = config->margin.top;
-	if (config->margin.bottom > config->margin.top) {
-		inner_margin = config->margin.bottom;
+	int inner_margin = style->margin.top;
+	if (style->margin.bottom > style->margin.top) {
+		inner_margin = style->margin.bottom;
 	}
 
 	int notif_width = state->width;
@@ -139,19 +140,19 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 	struct mako_notification *notif;
 	wl_list_for_each(notif, &state->notifications, link) {
 		size_t text_len =
-			format_text(config->format, NULL, format_notif_text, notif);
+			format_text(style->format, NULL, format_notif_text, notif);
 		char *text = malloc(text_len + 1);
 		if (text == NULL) {
 			break;
 		}
-		format_text(config->format, text, format_notif_text, notif);
+		format_text(style->format, text, format_notif_text, notif);
 
 		if (i > 0) {
 			total_height += inner_margin;
 		}
 
-		int notif_height = render_notification(cairo, state,
-				&config->default_style, text, total_height, scale);
+		int notif_height = render_notification(
+				cairo, state, style, text, total_height, scale);
 		free(text);
 
 		// Update hotspot
@@ -181,8 +182,8 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 		}
 		format_text(config->hidden_format, text, format_state_text, state);
 
-		int hidden_height = render_notification(cairo, state,
-				&config->default_style, text, total_height, scale);
+		int hidden_height = render_notification(
+				cairo, state, style, text, total_height, scale);
 		free(text);
 
 		total_height += hidden_height;

--- a/render.c
+++ b/render.c
@@ -114,7 +114,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 
 int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 	struct mako_config *config = &state->config;
-	struct mako_style *style = &config->default_style;
+	struct mako_style *style = &config->style;
 	cairo_t *cairo = buffer->cairo;
 
 	if (wl_list_empty(&state->notifications)) {

--- a/wayland.c
+++ b/wayland.c
@@ -409,12 +409,12 @@ void send_frame(struct mako_state *state) {
 
 		struct mako_config *config = &state->config;
 		zwlr_layer_surface_v1_set_size(state->layer_surface,
-			config->width, height);
+			config->style.width, height);
 		zwlr_layer_surface_v1_set_anchor(state->layer_surface,
 			ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
 		zwlr_layer_surface_v1_set_margin(state->layer_surface,
-			config->margin.top, config->margin.right, config->margin.bottom,
-			config->margin.left);
+			config->style.margin.top, config->style.margin.right,
+			config->style.margin.bottom, config->style.margin.left);
 		wl_surface_commit(state->surface);
 		return;
 	}
@@ -427,7 +427,7 @@ void send_frame(struct mako_state *state) {
 	// requested, we'll enter an infinite loop
 	if (state->height != height) {
 		zwlr_layer_surface_v1_set_size(state->layer_surface,
-			state->config.width, height);
+			state->config.style.width, height);
 		wl_surface_commit(state->surface);
 		return;
 	}


### PR DESCRIPTION
A prerequisite for #3 is to be able to store style information on each notification. This splits the style config bits out into their own struct to make this easier. I also split them up logically in `apply_config_option` to prepare for applying them to different criteria. A lot of this will be rearranged again further down the road, but this way any new features added in the meantime can already be in the right place.