### PR TITLE
Gracefully handle and report failure to reload config

### DIFF
--- a/config.c
+++ b/config.c
@@ -531,11 +531,7 @@ bool reload_config(struct mako_config *config) {
 	// currently pointing to local memory instead of the location of the real
 	// criteria struct.
 	wl_list_init(&config->criteria);
-	struct mako_criteria *criteria, *tmp;
-	wl_list_for_each_safe(criteria, tmp, &new_config.criteria, link) {
-		wl_list_remove(&criteria->link);
-		wl_list_insert(config->criteria.prev, &criteria->link);
-	}
+	wl_list_insert_list(&config->criteria, &new_config.criteria);
 
 	return true;
 }

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -71,10 +71,13 @@ static int handle_reload(sd_bus_message *msg, void *data,
 		sd_bus_error *ret_error) {
 	struct mako_state *state = data;
 
-	reload_config(&state->config);
+	if (!reload_config(&state->config)) {
+		return sd_bus_reply_method_return(msg, "b", false);
+	}
+
 	send_frame(state);
 
-	return sd_bus_reply_method_return(msg, "");
+	return sd_bus_reply_method_return(msg, "b", true);
 }
 
 static const sd_bus_vtable service_vtable[] = {
@@ -82,7 +85,7 @@ static const sd_bus_vtable service_vtable[] = {
 	SD_BUS_METHOD("DismissAllNotifications", "", "", handle_dismiss_all_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("DismissLastNotification", "", "", handle_dismiss_last_notification, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("InvokeAction", "s", "", handle_invoke_action, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("Reload", "", "", handle_reload, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("Reload", "", "b", handle_reload, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END
 };
 

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -72,12 +72,15 @@ static int handle_reload(sd_bus_message *msg, void *data,
 	struct mako_state *state = data;
 
 	if (!reload_config(&state->config)) {
-		return sd_bus_reply_method_return(msg, "b", false);
+		sd_bus_error_set_const(
+				ret_error, "fr.emersion.Mako.InvalidConfig",
+				"Unable to parse configuration file");
+		return -1;
 	}
 
 	send_frame(state);
 
-	return sd_bus_reply_method_return(msg, "b", true);
+	return sd_bus_reply_method_return(msg, "");
 }
 
 static const sd_bus_vtable service_vtable[] = {
@@ -85,7 +88,7 @@ static const sd_bus_vtable service_vtable[] = {
 	SD_BUS_METHOD("DismissAllNotifications", "", "", handle_dismiss_all_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("DismissLastNotification", "", "", handle_dismiss_last_notification, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("InvokeAction", "s", "", handle_invoke_action, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("Reload", "", "b", handle_reload, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("Reload", "", "", handle_reload, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END
 };
 

--- a/include/config.h
+++ b/include/config.h
@@ -85,6 +85,6 @@ bool apply_style(struct mako_style *target, const struct mako_style *style);
 
 int parse_config_arguments(struct mako_config *config, int argc, char **argv);
 int load_config_file(struct mako_config *config);
-void reload_config(struct mako_config *config);
+bool reload_config(struct mako_config *config);
 
 #endif

--- a/makoctl
+++ b/makoctl
@@ -40,11 +40,7 @@ case "$1" in
 	call InvokeAction "s" "$action"
 	;;
 "reload")
-	success=( $(call Reload) )
-	if [ "${success[1]}" == "false" ] ; then
-		echo "Failed to reload config" >&2
-		exit 1
-	fi
+	call Reload
 	;;
 "help"|"--help"|"-h")
 	usage

--- a/makoctl
+++ b/makoctl
@@ -40,7 +40,11 @@ case "$1" in
 	call InvokeAction "s" "$action"
 	;;
 "reload")
-	call Reload
+	success=( $(call Reload) )
+	if [ "${success[1]}" == "false" ] ; then
+		echo "Failed to reload config" >&2
+		exit 1
+	fi
 	;;
 "help"|"--help"|"-h")
 	usage


### PR DESCRIPTION
- Don't overwrite the config when reloading until it has been fully parsed (woo!)
- Make `reload_config` return a boolean
- Report the success or failure of reload over DBus
- Print a failure message and set the exit code of `makoctl` appropriately

Fixes #44.