### PR TITLE
Clean up notifications before the event loop

### DIFF
--- a/main.c
+++ b/main.c
@@ -49,13 +49,13 @@ static bool init(struct mako_state *state) {
 }
 
 static void finish(struct mako_state *state) {
-	finish_event_loop(&state->event_loop);
-	finish_wayland(state);
-	finish_dbus(state);
 	struct mako_notification *notif, *tmp;
 	wl_list_for_each_safe(notif, tmp, &state->notifications, link) {
 		destroy_notification(notif);
 	}
+	finish_event_loop(&state->event_loop);
+	finish_wayland(state);
+	finish_dbus(state);
 }
 
 static struct mako_event_loop *event_loop = NULL;


### PR DESCRIPTION
This allows the notifications to destroy their timers. Previously, all of the timers would be destroyed by `finish_event_loop`, then `finish_notification` would attempt to re-destroy them and become rather unhappy.

Fixes #50.