### PR TITLE
Break type parsing code into types.{c,h}

### DIFF
--- a/config.c
+++ b/config.c
@@ -10,6 +10,7 @@
 
 #include "config.h"
 #include "criteria.h"
+#include "types.h"
 
 void init_default_config(struct mako_config *config) {
 	wl_list_init(&config->criteria);
@@ -176,92 +177,6 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 		target->spec.colors.border = true;
 	}
 
-	return true;
-}
-
-static bool parse_int(const char *s, int *out) {
-	errno = 0;
-	char *end;
-	*out = (int)strtol(s, &end, 10);
-	return errno == 0 && end[0] == '\0';
-}
-
-/* Parse between 1 and 4 integers, comma separated, from the provided string.
- * Depending on the number of integers provided, the four fields of the `out`
- * struct will be initialized following the same rules as the CSS "margin"
- * property.
- */
-static bool parse_directional(const char *directional_string,
-		struct mako_directional *out) {
-	char *components = strdup(directional_string);
-
-	int32_t values[] = {0, 0, 0, 0};
-
-	char *saveptr = NULL;
-	char *token = strtok_r(components, ",", &saveptr);
-	size_t count;
-	for (count = 0; count < 4; count++) {
-		if (token == NULL) {
-			break;
-		}
-
-		int32_t number;
-		if (!parse_int(token, &number)) {
-			// There were no digits, or something else went horribly wrong
-			free(components);
-			return false;
-		}
-
-		values[count] = number;
-		token = strtok_r(NULL, ",", &saveptr);
-	}
-
-	switch (count) {
-	case 1: // All values are the same
-		out->top = out->right = out->bottom = out->left = values[0];
-		break;
-	case 2: // Vertical, horizontal
-		out->top = out->bottom = values[0];
-		out->right = out->left = values[1];
-		break;
-	case 3: // Top, horizontal, bottom
-		out->top = values[0];
-		out->right = out->left = values[1];
-		out->bottom = values[2];
-		break;
-	case 4: // Top, right, bottom, left
-		out->top = values[0];
-		out->right = values[1];
-		out->bottom = values[2];
-		out->left = values[3];
-		break;
-	}
-
-	free(components);
-	return true;
-}
-
-static bool parse_color(const char *color, uint32_t *out) {
-	if (color[0] != '#') {
-		return false;
-	}
-	color++;
-
-	size_t len = strlen(color);
-	if (len != 6 && len != 8) {
-		return false;
-	}
-
-	errno = 0;
-	char *end;
-	*out = (uint32_t)strtoul(color, &end, 16);
-	if (errno != 0 || end[0] != '\0') {
-		return false;
-	}
-
-	if (len == 6) {
-		*out = (*out << 8) | 0xFF;
-	}
 	return true;
 }
 

--- a/config.c
+++ b/config.c
@@ -233,8 +233,7 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	} else if (strcmp(name, "border-color") == 0) {
 		return spec->colors.border = parse_color(value, &style->colors.border);
 	} else if (strcmp(name, "markup") == 0) {
-		style->markup = strcmp(value, "1") == 0;
-		return spec->markup = style->markup || strcmp(value, "0") == 0;
+		return spec->markup = parse_boolean(value, &style->markup);
 	} else if (strcmp(name, "format") == 0) {
 		free(style->format);
 		return spec->format = !!(style->format = strdup(value));
@@ -242,9 +241,8 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		return spec->default_timeout =
 			parse_int(value, &style->default_timeout);
 	} else if (strcmp(name, "ignore-timeout") == 0) {
-		style->ignore_timeout = strcmp(value, "1") == 0;
-		return spec->ignore_timeout = (
-				style->ignore_timeout || strcmp(value, "0") == 0);
+		return spec->ignore_timeout =
+			parse_boolean(value, &style->ignore_timeout);
 	}
 
 	return false;

--- a/criteria.c
+++ b/criteria.c
@@ -3,8 +3,8 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
-#include <strings.h>
 #include <wayland-client.h>
+
 #include "mako.h"
 #include "config.h"
 #include "criteria.h"
@@ -67,33 +67,6 @@ bool match_criteria(struct mako_criteria *criteria,
 	}
 
 	return true;
-}
-
-bool parse_boolean(const char *string, bool *out) {
-	if (strcasecmp(string, "true") == 0 || strcmp(string, "1") == 0) {
-		*out = true;
-		return true;
-	} else if (strcasecmp(string, "false") == 0 || strcmp(string, "0") == 0) {
-		*out = false;
-		return true;
-	}
-
-	return false;
-}
-
-bool parse_urgency(const char *string, enum mako_notification_urgency *out) {
-	if (strcasecmp(string, "low") == 0) {
-		*out = MAKO_NOTIFICATION_URGENCY_LOW;
-		return true;
-	} else if (strcasecmp(string, "normal") == 0) {
-		*out = MAKO_NOTIFICATION_URGENCY_NORMAL;
-		return true;
-	} else if (strcasecmp(string, "high") == 0) {
-		*out = MAKO_NOTIFICATION_URGENCY_HIGH;
-		return true;
-	}
-
-	return false;
 }
 
 bool parse_criteria(const char *string, struct mako_criteria *criteria) {

--- a/include/config.h
+++ b/include/config.h
@@ -5,12 +5,7 @@
 #include <stdint.h>
 #include <wayland-client.h>
 
-struct mako_directional {
-	int32_t top;
-	int32_t right;
-	int32_t bottom;
-	int32_t left;
-};
+#include "types.h"
 
 enum mako_button_binding {
 	MAKO_BUTTON_BINDING_NONE,

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -52,9 +52,6 @@ void destroy_criteria(struct mako_criteria *criteria);
 bool match_criteria(struct mako_criteria *criteria,
 		struct mako_notification *notif);
 
-bool parse_boolean(const char *string, bool *out);
-bool parse_urgency(const char *string, enum mako_notification_urgency *out);
-
 bool parse_criteria(const char *string, struct mako_criteria *criteria);
 bool apply_criteria_field(struct mako_criteria *criteria, char *token);
 

--- a/include/notification.h
+++ b/include/notification.h
@@ -6,13 +6,7 @@
 #include <wayland-client.h>
 
 #include "config.h"
-
-enum mako_notification_urgency {
-	MAKO_NOTIFICATION_URGENCY_LOW = 0,
-	MAKO_NOTIFICATION_URGENCY_NORMAL = 1,
-	MAKO_NOTIFICATION_URGENCY_HIGH = 2,
-	MAKO_NOTIFICATION_URGENCY_UNKNOWN = -1,
-};
+#include "types.h"
 
 struct mako_state;
 struct mako_timer;

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ executable(
 		'render.c',
 		'wayland.c',
 		'criteria.c',
+		'types.c',
 	]),
 	dependencies: [
 		cairo,

--- a/types.c
+++ b/types.c
@@ -1,0 +1,125 @@
+#define _POSIX_C_SOURCE 200809L
+#include <errno.h>
+#include <getopt.h>
+#include <libgen.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+#include <wayland-client.h>
+#include <wordexp.h>
+#include <unistd.h>
+
+#include "types.h"
+
+bool parse_boolean(const char *string, bool *out) {
+	if (strcasecmp(string, "true") == 0 || strcmp(string, "1") == 0) {
+		*out = true;
+		return true;
+	} else if (strcasecmp(string, "false") == 0 || strcmp(string, "0") == 0) {
+		*out = false;
+		return true;
+	}
+
+	return false;
+}
+
+bool parse_int(const char *string, int *out) {
+	errno = 0;
+	char *end;
+	*out = (int)strtol(string, &end, 10);
+	return errno == 0 && end[0] == '\0';
+}
+
+bool parse_color(const char *string, uint32_t *out) {
+	if (string[0] != '#') {
+		return false;
+	}
+	string++;
+
+	size_t len = strlen(string);
+	if (len != 6 && len != 8) {
+		return false;
+	}
+
+	errno = 0;
+	char *end;
+	*out = (uint32_t)strtoul(string, &end, 16);
+	if (errno != 0 || end[0] != '\0') {
+		return false;
+	}
+
+	if (len == 6) {
+		*out = (*out << 8) | 0xFF;
+	}
+	return true;
+}
+
+bool parse_urgency(const char *string, enum mako_notification_urgency *out) {
+	if (strcasecmp(string, "low") == 0) {
+		*out = MAKO_NOTIFICATION_URGENCY_LOW;
+		return true;
+	} else if (strcasecmp(string, "normal") == 0) {
+		*out = MAKO_NOTIFICATION_URGENCY_NORMAL;
+		return true;
+	} else if (strcasecmp(string, "high") == 0) {
+		*out = MAKO_NOTIFICATION_URGENCY_HIGH;
+		return true;
+	}
+
+	return false;
+}
+
+/* Parse between 1 and 4 integers, comma separated, from the provided string.
+ * Depending on the number of integers provided, the four fields of the `out`
+ * struct will be initialized following the same rules as the CSS "margin"
+ * property.
+ */
+bool parse_directional(const char *string, struct mako_directional *out) {
+	char *components = strdup(string);
+
+	int32_t values[] = {0, 0, 0, 0};
+
+	char *saveptr = NULL;
+	char *token = strtok_r(components, ",", &saveptr);
+	size_t count;
+	for (count = 0; count < 4; count++) {
+		if (token == NULL) {
+			break;
+		}
+
+		int32_t number;
+		if (!parse_int(token, &number)) {
+			// There were no digits, or something else went horribly wrong
+			free(components);
+			return false;
+		}
+
+		values[count] = number;
+		token = strtok_r(NULL, ",", &saveptr);
+	}
+
+	switch (count) {
+	case 1: // All values are the same
+		out->top = out->right = out->bottom = out->left = values[0];
+		break;
+	case 2: // Vertical, horizontal
+		out->top = out->bottom = values[0];
+		out->right = out->left = values[1];
+		break;
+	case 3: // Top, horizontal, bottom
+		out->top = values[0];
+		out->right = out->left = values[1];
+		out->bottom = values[2];
+		break;
+	case 4: // Top, right, bottom, left
+		out->top = values[0];
+		out->right = values[1];
+		out->bottom = values[2];
+		out->left = values[3];
+		break;
+	}
+
+	free(components);
+	return true;
+}

--- a/types.h
+++ b/types.h
@@ -1,0 +1,29 @@
+#ifndef _MAKO_TYPES_H
+#define _MAKO_TYPES_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+bool parse_boolean(const char *string, bool *out);
+bool parse_int(const char *string, int *out);
+bool parse_color(const char *string, uint32_t *out);
+
+enum mako_notification_urgency {
+	MAKO_NOTIFICATION_URGENCY_LOW = 0,
+	MAKO_NOTIFICATION_URGENCY_NORMAL = 1,
+	MAKO_NOTIFICATION_URGENCY_HIGH = 2,
+	MAKO_NOTIFICATION_URGENCY_UNKNOWN = -1,
+};
+
+bool parse_urgency(const char *string, enum mako_notification_urgency *out);
+
+struct mako_directional {
+	int32_t top;
+	int32_t right;
+	int32_t bottom;
+	int32_t left;
+};
+
+bool parse_directional(const char *string, struct mako_directional *out);
+
+#endif


### PR DESCRIPTION
This centralizes the parsing functions for the "just data" types so that it's easier to share them between components. It also shrinks config.c just a bit, and every bit helps.

I also now use `parse_boolean` to parse the appropriate style options.