### PR TITLE
Add 'expiring' criteria

### DIFF
--- a/criteria.c
+++ b/criteria.c
@@ -51,6 +51,11 @@ bool match_criteria(struct mako_criteria *criteria,
 		return false;
 	}
 
+	if (spec.expiring &&
+			criteria->expiring != (notif->requested_timeout != 0)) {
+		return false;
+	}
+
 	if (spec.urgency &&
 			criteria->urgency != notif->urgency) {
 		return false;
@@ -228,6 +233,14 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token) {
 			return false;
 		}
 		criteria->spec.actionable = true;
+		return true;
+	} else if (strcmp(key, "expiring") == 0){
+		if (!parse_boolean(value, &criteria->expiring)) {
+			fprintf(stderr, "Invalid value '%s' for boolean field '%s'\n",
+					value, key);
+			return false;
+		}
+		criteria->spec.expiring = true;
 		return true;
 	} else {
 		if (bare_key) {

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -207,11 +207,12 @@ static int handle_notify(sd_bus_message *msg, void *data,
 		return ret;
 	}
 
-	int32_t expire_timeout;
-	ret = sd_bus_message_read(msg, "i", &expire_timeout);
+	int32_t requested_timeout;
+	ret = sd_bus_message_read(msg, "i", &requested_timeout);
 	if (ret < 0) {
 		return ret;
 	}
+	notif->requested_timeout = requested_timeout;
 
 	int match_count = apply_each_criteria(&state->config.criteria, notif);
 	if (match_count == -1) {
@@ -227,7 +228,8 @@ static int handle_notify(sd_bus_message *msg, void *data,
 		return -1;
 	}
 
-	if (expire_timeout < 0 || notif->style.ignore_timeout) {
+	int32_t expire_timeout;
+	if (notif->requested_timeout < 0 || notif->style.ignore_timeout) {
 		expire_timeout = notif->style.default_timeout;
 	}
 

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -25,6 +25,7 @@ struct mako_criteria_spec {
 	bool app_name;
 	bool app_icon;
 	bool actionable;
+	bool expiring;
 	bool urgency;
 	bool category;
 	bool desktop_entry;
@@ -41,6 +42,7 @@ struct mako_criteria {
 	char *app_name;
 	char *app_icon;
 	bool actionable; // Whether mako_notification.actions is nonempty
+	bool expiring; // Whether mako_notification.timer is non-null
 
 	enum mako_notification_urgency urgency;
 	char *category;

--- a/include/notification.h
+++ b/include/notification.h
@@ -27,6 +27,7 @@ struct mako_notification {
 	char *app_icon;
 	char *summary;
 	char *body;
+	int32_t requested_timeout;
 	struct wl_list actions; // mako_action::link
 
 	enum mako_notification_urgency urgency;


### PR DESCRIPTION
A criteria to match whether a notification will ever disappear on its own.

This allows you to set `ignore-timeout` + `default-timeout` on non-expiring notifications in general, rather than having to match on applications that tend to send them. This effectively prevents non-expiring notifications entirely:
```
[!expiring]
ignore-timeout=true
default-timeout=5000
```
Obviously you can do other things with it as well, but this is the most immediately useful application.

This also adds a field to `mako_notification` to track the requested timeout, as opposed to what we decided to give it. This was necessary for the value to be present at the time criteria are applied. This means that you can only match based on the timeout that the notifier requested, not what you have overridden it to be in other criteria sections using `ignore-timeout`. There's no way to "fix" this without introducing multiple stages of criteria matching, which is a road I really don't want to go down. This case is a bit unique, as `ignore-timeout` is the only option which has the effect of changing something provided by the notifier.

I don't see this as a big issue, as if you are overriding the timeout for something specific, you can also just set the other style options in that criteria section.