### PR TITLE
Introduce anchor option

### DIFF
--- a/config.c
+++ b/config.c
@@ -208,16 +208,16 @@ static bool apply_config_option(struct mako_config *config, const char *name,
 		}
 		return true;
 	} else if (strcmp(name, "anchor") == 0) {
-		if (strcmp(value, "topright") == 0) {
+		if (strcmp(value, "top-right") == 0) {
 			config->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
 				ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
-		} else if (strcmp(value, "bottomright") == 0) {
+		} else if (strcmp(value, "bottom-right") == 0) {
 			config->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
 				ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
-		} else if (strcmp(value, "bottomleft") == 0) {
+		} else if (strcmp(value, "bottom-left") == 0) {
 			config->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
 				ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
-		} else if (strcmp(value, "topleft") == 0) {
+		} else if (strcmp(value, "top-left") == 0) {
 			config->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
 				ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
 		} else {

--- a/include/config.h
+++ b/include/config.h
@@ -60,6 +60,7 @@ struct mako_config {
 
 	int32_t max_visible;
 	char *output;
+	uint32_t anchor;
 	uint32_t sort_criteria; //enum mako_sort_criteria
 	uint32_t sort_asc;
 

--- a/main.c
+++ b/main.c
@@ -32,6 +32,7 @@ static const char usage[] =
 	"      --max-visible <n>           Max number of visible notifications.\n"
 	"      --default-timeout <timeout> Default timeout in milliseconds.\n"
 	"      --output <name>             Show notifications on this output.\n"
+	"      --anchor <corner>           Corner of output to put notifications.\n"
 	"\n"
 	"Colors can be specified with the format #RRGGBB or #RRGGBBAA.\n";
 

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -44,9 +44,9 @@ dismissed with a click or via *makoctl*(1).
 
 *--anchor* _corner_
 	Show notifications in the specified corner of the output. Supported values
-	are _topright_, _bottomright_, _bottomleft_ and _topleft_.
+	are _top-right_, _bottom-right_, _bottom-left_ and _top-left_.
 
-	Default: _topright_
+	Default: _top-right_
 
 # STYLE OPTIONS
 

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -42,6 +42,12 @@ dismissed with a click or via *makoctl*(1).
 
 	Default: ""
 
+*--anchor* _corner_
+	Show notifications in the specified corner of the output. Supported values
+	are _topright_, _bottomright_, _bottomleft_ and _topleft_.
+
+	Default: _topright_
+
 # STYLE OPTIONS
 
 *--font* _font_

--- a/wayland.c
+++ b/wayland.c
@@ -414,7 +414,7 @@ void send_frame(struct mako_state *state) {
 		zwlr_layer_surface_v1_set_size(state->layer_surface, style->width,
 				height);
 		zwlr_layer_surface_v1_set_anchor(state->layer_surface,
-			ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
+				state->config.anchor);
 		zwlr_layer_surface_v1_set_margin(state->layer_surface,
 			style->margin.top, style->margin.right,
 			style->margin.bottom, style->margin.left);


### PR DESCRIPTION
This adds an `anchor` option, to allow the user to choose which corner of the output the notifications should appear in.

Usage:

`--anchor topright|bottomright|bottomleft|topleft`