### PR TITLE
add support for [\n] character format parameter inside config file

### DIFF
--- a/config.c
+++ b/config.c
@@ -257,7 +257,7 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		return spec->markup = parse_boolean(value, &style->markup);
 	} else if (strcmp(name, "format") == 0) {
 		free(style->format);
-		return spec->format = !!(style->format = strdup(value));
+		return spec->format = parse_format(value, &style->format);
 	} else if (strcmp(name, "default-timeout") == 0) {
 		return spec->default_timeout =
 			parse_int(value, &style->default_timeout);

--- a/criteria.c
+++ b/criteria.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <wayland-client.h>
 
+#include "enum.h"
 #include "mako.h"
 #include "config.h"
 #include "criteria.h"

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -8,15 +8,6 @@
 
 struct mako_config;
 
-// State is intended to work as a bitmask, so if more need to be added in the
-// future, this should be taken into account.
-enum mako_parse_state {
-	MAKO_PARSE_STATE_NORMAL = 0,
-	MAKO_PARSE_STATE_ESCAPE = 1,
-	MAKO_PARSE_STATE_QUOTE = 2,
-	MAKO_PARSE_STATE_QUOTE_ESCAPE = 3,
-};
-
 // Stores whether or not each field was part of the criteria specification, so
 // that, for example, "not actionable" can be distinguished from "don't care".
 // This is unnecessary for string fields, but it's best to just keep it

--- a/include/enum.h
+++ b/include/enum.h
@@ -1,0 +1,13 @@
+#ifndef _ENUM_H_
+#define _ENUM_H_
+
+// State is intended to work as a bitmask, so if more need to be added in the
+// future, this should be taken into account.
+enum mako_parse_state {
+	MAKO_PARSE_STATE_NORMAL = 0,
+	MAKO_PARSE_STATE_ESCAPE = 1,
+	MAKO_PARSE_STATE_QUOTE = 2,
+	MAKO_PARSE_STATE_QUOTE_ESCAPE = 3,
+};
+
+#endif

--- a/include/types.h
+++ b/include/types.h
@@ -25,5 +25,6 @@ struct mako_directional {
 };
 
 bool parse_directional(const char *string, struct mako_directional *out);
+bool parse_format(const char *string, char **out);
 
 #endif

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -210,6 +210,10 @@ specifiers.
 
 *%%*	Literal "%"
 
+*\\\\*	Literal "\\"
+
+*\\n*	New Line 
+
 ## For notifications
 
 *%a*	Application name

--- a/types.c
+++ b/types.c
@@ -126,16 +126,15 @@ bool parse_directional(const char *string, struct mako_directional *out) {
 }
 
 bool parse_format(const char *string, char **out) {
-	int token_max_length = strlen(string) + 1;
+	size_t token_max_length = strlen(string) + 1;
 	char token[token_max_length];
 	memset(token, 0, token_max_length);
 	size_t token_location = 0;
 
 	enum mako_parse_state state = MAKO_PARSE_STATE_NORMAL;
-	const char *location = string;
+	for (size_t i = 0; i < token_max_length; ++i) {
+		char ch = string[i];
 
-	char ch;
-	while ((ch = *location++) != '\0') {
 		switch (state) {
 		case MAKO_PARSE_STATE_ESCAPE:
 			switch (ch) {
@@ -145,7 +144,12 @@ bool parse_format(const char *string, char **out) {
 				break;
 
 			case '\\':
+				token[token_location] = '\\';
+				++token_location;
+				break;
+
 			default:
+				++token_location;
 				token[token_location] = ch;
 				++token_location;
 				break;
@@ -157,6 +161,7 @@ bool parse_format(const char *string, char **out) {
 		case MAKO_PARSE_STATE_NORMAL:
 			switch (ch) {
 			case '\\':
+				token[token_location] = ch;
 				state = MAKO_PARSE_STATE_ESCAPE;
 				break;
 

--- a/types.c
+++ b/types.c
@@ -137,39 +137,39 @@ bool parse_format(const char *string, char **out) {
 	char ch;
 	while ((ch = *location++) != '\0') {
 		switch (state) {
-			case MAKO_PARSE_STATE_ESCAPE:
-				switch (ch) {
-					case 'n':
-						token[token_location] = '\n';
-						++token_location;
-						break;
-
-					case '\\':
-					default:
-						token[token_location] = ch;
-						++token_location;
-						break;
-				}
-
-				state = MAKO_PARSE_STATE_NORMAL;
+		case MAKO_PARSE_STATE_ESCAPE:
+			switch (ch) {
+			case 'n':
+				token[token_location] = '\n';
+				++token_location;
 				break;
 
-			case MAKO_PARSE_STATE_NORMAL:
-				switch (ch) {
-					case '\\':
-						state = MAKO_PARSE_STATE_ESCAPE;
-						break;
+			case '\\':
+			default:
+				token[token_location] = ch;
+				++token_location;
+				break;
+			}
 
-					default:
-						token[token_location] = ch;
-						++token_location;
-						break;
-				}
+			state = MAKO_PARSE_STATE_NORMAL;
+			break;
+
+		case MAKO_PARSE_STATE_NORMAL:
+			switch (ch) {
+			case '\\':
+				state = MAKO_PARSE_STATE_ESCAPE;
 				break;
 
 			default:
-				*out = NULL;
-				return false;
+				token[token_location] = ch;
+				++token_location;
+				break;
+			}
+			break;
+
+		default:
+			*out = NULL;
+			return false;
 		}
 	}
 


### PR DESCRIPTION
This fixes #61 
As a consequence also the char `\` needs to be escaped.

i'll update the `mako.1.sdc` file once the modification are approved