### PR TITLE
Allow overriding horizontal margins in criteria

### DIFF
--- a/render.c
+++ b/render.c
@@ -79,10 +79,13 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	int notif_width =
 		(style->width <= state->width) ? style->width : state->width;
 
-	// Calculate the appropriate offset if we're right-aligned.
-	bool right_align =
-		(state->config.anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
-	int offset_x = right_align ? (state->width - notif_width) : 0;
+	int offset_x;
+	if (state->config.anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT) {
+		offset_x = state->width - notif_width - style->margin.right;
+	}
+	else {
+		offset_x = style->margin.left;
+	}
 
 	set_font_options(cairo, state);
 

--- a/render.c
+++ b/render.c
@@ -82,8 +82,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	int offset_x;
 	if (state->config.anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT) {
 		offset_x = state->width - notif_width - style->margin.right;
-	}
-	else {
+	} else {
 		offset_x = style->margin.left;
 	}
 

--- a/render.c
+++ b/render.c
@@ -197,12 +197,10 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 		}
 		format_text(style->format, text, format_notif_text, notif);
 
-		if (i > 0) {
-			if (style->margin.top > pending_bottom_margin) {
-				total_height += style->margin.top;
-			} else {
-				total_height += pending_bottom_margin;
-			}
+		if (style->margin.top > pending_bottom_margin) {
+			total_height += style->margin.top;
+		} else {
+			total_height += pending_bottom_margin;
 		}
 
 		int notif_width =

--- a/wayland.c
+++ b/wayland.c
@@ -433,9 +433,6 @@ void send_frame(struct mako_state *state) {
 				height);
 		zwlr_layer_surface_v1_set_anchor(state->layer_surface,
 				state->config.anchor);
-		zwlr_layer_surface_v1_set_margin(state->layer_surface,
-			style->margin.top, style->margin.right,
-			style->margin.bottom, style->margin.left);
 		wl_surface_commit(state->surface);
 		return;
 	}

--- a/wayland.c
+++ b/wayland.c
@@ -426,27 +426,23 @@ void send_frame(struct mako_state *state) {
 			ZWLR_LAYER_SHELL_V1_LAYER_TOP, "notifications");
 		zwlr_layer_surface_v1_add_listener(state->layer_surface,
 			&layer_surface_listener, state);
+	}
 
+	// If the block above executed, this one always will as well.
+	// TODO: if the compositor doesn't send a configure with the size we
+	// requested, we'll enter an infinite loop
+	if (state->height != height) {
 		struct mako_style *style = &state->config.superstyle;
 
-		zwlr_layer_surface_v1_set_size(state->layer_surface, style->width,
+		zwlr_layer_surface_v1_set_size(state->layer_surface,
+				style->width + style->margin.left + style->margin.right,
 				height);
 		zwlr_layer_surface_v1_set_anchor(state->layer_surface,
 				state->config.anchor);
 		wl_surface_commit(state->surface);
-		return;
-	}
 
-	if (!state->configured) {
-		return;
-	}
-
-	// TODO: if the compositor doesn't send a configure with the size we
-	// requested, we'll enter an infinite loop
-	if (state->height != height) {
-		zwlr_layer_surface_v1_set_size(state->layer_surface,
-			state->config.superstyle.width, height);
-		wl_surface_commit(state->surface);
+		// Early return because we don't actually have a surface to draw on
+		// yet. We will soon be called again by layer_surface_handle_configure.
 		return;
 	}
 

--- a/wayland.c
+++ b/wayland.c
@@ -1,4 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
+#include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Fixes #48. As we had discussed at some point in the distant past, I had to remove the margin from around the layer surface for this.

I also unified the calls to `zwlr_layer_surface_v1_set_size` during `send_frame`. I couldn't find any situations where the early return when unconfigured actually happened, but if you had one in mind when you added it originally I can put it back.