### PR TITLE
Improve body parsing

### DIFF
--- a/notification.c
+++ b/notification.c
@@ -187,7 +187,7 @@ char *format_notif_text(char variable, bool *markup, void *data) {
 	case 's':
 		return strdup(notif->summary);
 	case 'b':
-		*markup = true;
+		*markup = notif->style.markup;
 		return strdup(notif->body);
 	}
 	return NULL;

--- a/notification.c
+++ b/notification.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <pango/pangocairo.h>
 #include <wayland-client.h>
 #ifdef __linux__
 #include <linux/input-event-codes.h>
@@ -226,7 +227,7 @@ size_t format_text(const char *format, char *buf, mako_format_func_t format_func
 		}
 
 		size_t value_len;
-		if (!markup) {
+		if (!markup || !pango_parse_markup(value, -1, 0, NULL, NULL, NULL, NULL)) {
 			char *escaped = NULL;
 			if (buf != NULL) {
 				escaped = buf + len;

--- a/render.c
+++ b/render.c
@@ -101,19 +101,15 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	pango_font_description_free(desc);
 
 	PangoAttrList *attrs = NULL;
-	if (style->markup) {
-		GError *error = NULL;
-		char *buf = NULL;
-		if (pango_parse_markup(text, -1, 0, &attrs, &buf, NULL, &error)) {
-			pango_layout_set_text(layout, buf, -1);
-			free(buf);
-		} else {
-			fprintf(stderr, "cannot parse pango markup: %s\n", error->message);
-			g_error_free(error);
-			// fallback to plain text
-			pango_layout_set_text(layout, text, -1);
-		}
+	GError *error = NULL;
+	char *buf = NULL;
+	if (pango_parse_markup(text, -1, 0, &attrs, &buf, NULL, &error)) {
+		pango_layout_set_text(layout, buf, -1);
+		free(buf);
 	} else {
+		fprintf(stderr, "cannot parse pango markup: %s\n", error->message);
+		g_error_free(error);
+		// fallback to plain text
 		pango_layout_set_text(layout, text, -1);
 	}
 


### PR DESCRIPTION
When receiving invalid markup in a notification, escape it even if markup is enabled. This prevents the bad markup from breaking the user's defined `format`. Additionally, the `markup` flag now only applies to application-provided content (i.e., the body). If a user doesn't want markup in their style, they should change `format` anyway since the default is quite ugly without markup enabled.

Fixes #55.

---
![screenshot_2018-10-14-125128](https://user-images.githubusercontent.com/201439/46919626-fc110380-cfaf-11e8-974c-26bb870d9831.png)
A notification containing invalid markup which still formats correctly.

![screenshot_2018-10-14-125308](https://user-images.githubusercontent.com/201439/46919634-21057680-cfb0-11e8-8791-2ece92bf0891.png)
A notification containing valid markup, but with `markup=false`.