### PR TITLE
Add `layer` option

### DIFF
--- a/config.c
+++ b/config.c
@@ -12,7 +12,6 @@
 #include "config.h"
 #include "criteria.h"
 #include "types.h"
-#include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
 
 static int32_t max(int32_t a, int32_t b) {
@@ -32,8 +31,9 @@ void init_default_config(struct mako_config *config) {
 	config->hidden_style.spec.format = true;
 
 	config->output = strdup("");
-	config->max_visible = 5;
+	config->layer = ZWLR_LAYER_SHELL_V1_LAYER_TOP;
 
+	config->max_visible = 5;
 	config->sort_criteria = MAKO_SORT_CRITERIA_TIME;
 	config->sort_asc = 0;
 
@@ -288,6 +288,19 @@ static bool apply_config_option(struct mako_config *config, const char *name,
 		free(config->output);
 		config->output = strdup(value);
 		return true;
+	} else if (strcmp(name, "layer") == 0) {
+		if (strcmp(value, "background") == 0) {
+			config->layer = ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND;
+		} else if (strcmp(value, "bottom") == 0) {
+			config->layer = ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
+		} else if (strcmp(value, "top") == 0) {
+			config->layer = ZWLR_LAYER_SHELL_V1_LAYER_TOP;
+		} else if (strcmp(value, "overlay") == 0) {
+			config->layer = ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY;
+		} else {
+			return false;
+		}
+		return true;
 	} else if (strcmp(name, "sort") == 0) {
 		if (strcmp(value, "+priority") == 0) {
 			config->sort_criteria |= MAKO_SORT_CRITERIA_URGENCY;
@@ -301,6 +314,8 @@ static bool apply_config_option(struct mako_config *config, const char *name,
 		} else if (strcmp(value, "-time") == 0) {
 			config->sort_criteria |= MAKO_SORT_CRITERIA_TIME;
 			config->sort_asc &= ~MAKO_SORT_CRITERIA_TIME;
+		} else {
+			return false;
 		}
 		return true;
 	} else if (strcmp(name, "anchor") == 0) {
@@ -521,6 +536,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"default-timeout", required_argument, 0, 0},
 		{"ignore-timeout", required_argument, 0, 0},
 		{"output", required_argument, 0, 0},
+		{"layer", required_argument, 0, 0},
 		{"anchor", required_argument, 0, 0},
 		{"sort", required_argument, 0, 0},
 		{0},

--- a/include/config.h
+++ b/include/config.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <wayland-client.h>
 
+#include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #include "types.h"
 
 enum mako_button_binding {
@@ -60,6 +61,7 @@ struct mako_config {
 
 	int32_t max_visible;
 	char *output;
+	enum zwlr_layer_shell_v1_layer layer;
 	uint32_t anchor;
 	uint32_t sort_criteria; //enum mako_sort_criteria
 	uint32_t sort_asc;

--- a/main.c
+++ b/main.c
@@ -34,6 +34,7 @@ static const char usage[] =
 	"      --max-visible <n>           Max number of visible notifications.\n"
 	"      --default-timeout <timeout> Default timeout in milliseconds.\n"
 	"      --output <name>             Show notifications on this output.\n"
+	"      --layer <layer>             Arrange notifications at this layer.\n"
 	"      --anchor <position>         Position on output to put notifications.\n"
 	"\n"
 	"Colors can be specified with the format #RRGGBB or #RRGGBBAA.\n";

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -42,12 +42,20 @@ dismissed with a click or via *makoctl*(1).
 
 	Default: ""
 
+*--layer* _layer_
+	Arrange mako at the specified layer, relative to normal windows. Supported
+	values are _background_, _bottom_, _top_, and _overlay_. Using _overlay_
+	will cause notifications to be displayed above fullscreen windows, though
+	this may also occur at _top_ depending on your compositor.
+
+	Default: top
+
 *--anchor* _position_
 	Show notifications at the specified position on the output. Supported values
 	are _top-right_, _bottom-right_, _bottom-center_, _bottom-left_, _top-left_
 	and _top-center_.
 
-	Default: _top-right_
+	Default: top-right
 
 # STYLE OPTIONS
 
@@ -220,7 +228,7 @@ specifiers.
 
 *\\\\*	Literal "\\"
 
-*\\n*	New Line 
+*\\n*	New Line
 
 ## For notifications
 

--- a/wayland.c
+++ b/wayland.c
@@ -431,7 +431,7 @@ void send_frame(struct mako_state *state) {
 
 		state->layer_surface = zwlr_layer_shell_v1_get_layer_surface(
 			state->layer_shell, state->surface, wl_output,
-			ZWLR_LAYER_SHELL_V1_LAYER_TOP, "notifications");
+			state->config.layer, "notifications");
 		zwlr_layer_surface_v1_add_listener(state->layer_surface,
 			&layer_surface_listener, state);
 


### PR DESCRIPTION
Allows the layer that the surface is drawn at to be set, mostly so you can choose `overlay` if you want it to appear over fullscreen windows. I added `bottom` and `background` as well because it was easy, I can't imagine actually wanting either. Default is still `top`.