### PR TITLE
Missing include string.h in pool-buffer.c

### DIFF
--- a/pool-buffer.c
+++ b/pool-buffer.c
@@ -6,6 +6,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <wayland-client.h>
+#include <string.h>
 
 #include "pool-buffer.h"
 


### PR DESCRIPTION
Hey there,
Thanks for this nice piece of code!
I tried to install it on gentoo, via the [sorrow overlay](https://gitlab.com/eternal-sorrow/gentoo-local) which should match the latest git status, but the compilation failed on pool-buffer.c, as some functions were used without the appropriate library being included…
Simply adding `#include <string.h>` to this file, as suggested by the error log, solved the issue.
Attached is my initial (failed) [build.log](https://github.com/emersion/mako/files/2609780/build.log).
Cheers
