### PR TITLE
Grouping

### DIFF
--- a/config.c
+++ b/config.c
@@ -84,6 +84,9 @@ void init_default_style(struct mako_style *style) {
 	style->colors.text = 0xFFFFFFFF;
 	style->colors.border = 0x4C7899FF;
 
+	// Only completely identical notifications should group by default.
+	memset(&style->group_criteria_spec, true, sizeof(struct mako_criteria_spec));
+
 	// Everything in the default config is explicitly specified.
 	memset(&style->spec, true, sizeof(struct mako_style_spec));
 }
@@ -194,6 +197,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 	if (style->spec.colors.border) {
 		target->colors.border = style->colors.border;
 		target->spec.colors.border = true;
+	}
+
+	if (style->spec.group_criteria_spec) {
+		target->group_criteria_spec = style->group_criteria_spec;
+		target->spec.group_criteria_spec = true;
 	}
 
 	return true;
@@ -381,6 +389,9 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	} else if (strcmp(name, "ignore-timeout") == 0) {
 		return spec->ignore_timeout =
 			parse_boolean(value, &style->ignore_timeout);
+	} else if (strcmp(name, "group") == 0) {
+		return spec->group_criteria_spec =
+			parse_criteria_spec(value, &style->group_criteria_spec);
 	}
 
 	return false;

--- a/criteria.c
+++ b/criteria.c
@@ -177,46 +177,6 @@ bool parse_criteria(const char *string, struct mako_criteria *criteria) {
 	return true;
 }
 
-bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out) {
-	// Clear any existing specified fields in the output spec.
-	memset(out, 0, sizeof(struct mako_criteria_spec));
-
-	char *components = strdup(string);
-	char *saveptr = NULL;
-	char *token = strtok_r(components, ",", &saveptr);
-
-	while (token) {
-		// Can't just use &= because then we nave no way to report invalid
-		// values. :(
-		if (strcmp(token, "app-name") == 0) {
-			out->app_name = true;
-		} else if (strcmp(token, "app-icon") == 0) {
-			out->app_icon = true;
-		} else if (strcmp(token, "actionable") == 0) {
-			out->actionable = true;
-		} else if (strcmp(token, "expiring") == 0) {
-			out->expiring = true;
-		} else if (strcmp(token, "urgency") == 0) {
-			out->urgency = true;
-		} else if (strcmp(token, "category") == 0) {
-			out->category = true;
-		} else if (strcmp(token, "desktop-entry") == 0) {
-			out->desktop_entry = true;
-		} else if (strcmp(token, "summary") == 0) {
-			out->summary = true;
-		} else if (strcmp(token, "body") == 0) {
-			out->body = true;
-		} else {
-			fprintf(stderr, "Unknown criteria field '%s'\n", token);
-			return false;
-		}
-
-		token = strtok_r(NULL, ",", &saveptr);
-	}
-
-	return true;
-}
-
 // Takes a token from the criteria string that looks like "key=value", figures
 // out which field of the criteria "key" refers to, and sets it to "value".
 // Any further equal signs are assumed to be part of the value. If there is no .

--- a/criteria.c
+++ b/criteria.c
@@ -31,6 +31,8 @@ void destroy_criteria(struct mako_criteria *criteria) {
 	free(criteria->app_icon);
 	free(criteria->category);
 	free(criteria->desktop_entry);
+	free(criteria->summary);
+	free(criteria->body);
 	free(criteria);
 }
 
@@ -70,6 +72,16 @@ bool match_criteria(struct mako_criteria *criteria,
 
 	if (spec.desktop_entry &&
 			strcmp(criteria->desktop_entry, notif->desktop_entry) != 0) {
+		return false;
+	}
+
+	if (spec.summary &&
+			strcmp(criteria->summary, notif->summary) != 0) {
+		return false;
+	}
+
+	if (spec.body &&
+			strcmp(criteria->body, notif->body) != 0) {
 		return false;
 	}
 
@@ -227,6 +239,7 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token) {
 			criteria->spec.desktop_entry = true;
 			return true;
 		} else {
+			// TODO: summary + body, once we support regex and they're useful.
 			// Anything left must be one of the boolean fields, defined using
 			// standard syntax. Continue on.
 		}
@@ -316,6 +329,8 @@ struct mako_criteria *create_criteria_from_notification(
 	criteria->urgency = notif->urgency;
 	criteria->category = strdup(notif->category);
 	criteria->desktop_entry = strdup(notif->desktop_entry);
+	criteria->summary = strdup(notif->summary);
+	criteria->body = strdup(notif->body);
 
 	return criteria;
 }

--- a/criteria.c
+++ b/criteria.c
@@ -177,6 +177,46 @@ bool parse_criteria(const char *string, struct mako_criteria *criteria) {
 	return true;
 }
 
+bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out) {
+	// Clear any existing specified fields in the output spec.
+	memset(out, 0, sizeof(struct mako_criteria_spec));
+
+	char *components = strdup(string);
+	char *saveptr = NULL;
+	char *token = strtok_r(components, ",", &saveptr);
+
+	while (token) {
+		// Can't just use &= because then we nave no way to report invalid
+		// values. :(
+		if (strcmp(token, "app-name") == 0) {
+			out->app_name = true;
+		} else if (strcmp(token, "app-icon") == 0) {
+			out->app_icon = true;
+		} else if (strcmp(token, "actionable") == 0) {
+			out->actionable = true;
+		} else if (strcmp(token, "expiring") == 0) {
+			out->expiring = true;
+		} else if (strcmp(token, "urgency") == 0) {
+			out->urgency = true;
+		} else if (strcmp(token, "category") == 0) {
+			out->category = true;
+		} else if (strcmp(token, "desktop-entry") == 0) {
+			out->desktop_entry = true;
+		} else if (strcmp(token, "summary") == 0) {
+			out->summary = true;
+		} else if (strcmp(token, "body") == 0) {
+			out->body = true;
+		} else {
+			fprintf(stderr, "Unknown criteria field '%s'\n", token);
+			return false;
+		}
+
+		token = strtok_r(NULL, ",", &saveptr);
+	}
+
+	return true;
+}
+
 // Takes a token from the criteria string that looks like "key=value", figures
 // out which field of the criteria "key" refers to, and sets it to "value".
 // Any further equal signs are assumed to be part of the value. If there is no .

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -92,6 +92,12 @@ static int handle_notify(sd_bus_message *msg, void *data,
 	if (ret < 0) {
 		return ret;
 	}
+
+	free(notif->app_name);
+	free(notif->app_icon);
+	free(notif->summary);
+	free(notif->body);
+
 	notif->app_name = strdup(app_name);
 	notif->app_icon = strdup(app_icon);
 	notif->summary = strdup(summary);
@@ -182,6 +188,7 @@ static int handle_notify(sd_bus_message *msg, void *data,
 			if (ret < 0) {
 				return ret;
 			}
+			free(notif->category);
 			notif->category = strdup(category);
 		} else if (strcmp(hint, "desktop-entry") == 0) {
 			const char *desktop_entry = NULL;
@@ -189,6 +196,7 @@ static int handle_notify(sd_bus_message *msg, void *data,
 			if (ret < 0) {
 				return ret;
 			}
+			free(notif->desktop_entry);
 			notif->desktop_entry = strdup(desktop_entry);
 		} else {
 			ret = sd_bus_message_skip(msg, "v");

--- a/include/config.h
+++ b/include/config.h
@@ -5,8 +5,9 @@
 #include <stdint.h>
 #include <wayland-client.h>
 
-#include "wlr-layer-shell-unstable-v1-client-protocol.h"
+#include "criteria.h"
 #include "types.h"
+#include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
 enum mako_button_binding {
 	MAKO_BUTTON_BINDING_NONE,
@@ -25,7 +26,7 @@ enum mako_sort_criteria {
 // structs are also mirrored.
 struct mako_style_spec {
 	bool width, height, margin, padding, border_size, font, markup, format,
-		 actions, default_timeout, ignore_timeout;
+		 actions, default_timeout, ignore_timeout, group_criteria_spec;
 
 	struct {
 		bool background, text, border;
@@ -54,6 +55,8 @@ struct mako_style {
 		uint32_t text;
 		uint32_t border;
 	} colors;
+
+	struct mako_criteria_spec group_criteria_spec;
 };
 
 struct mako_config {

--- a/include/config.h
+++ b/include/config.h
@@ -4,8 +4,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <wayland-client.h>
-
-#include "criteria.h"
 #include "types.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -49,6 +49,8 @@ bool match_criteria(struct mako_criteria *criteria,
 		struct mako_notification *notif);
 
 bool parse_criteria(const char *string, struct mako_criteria *criteria);
+bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out);
+
 bool apply_criteria_field(struct mako_criteria *criteria, char *token);
 
 struct mako_criteria *global_criteria(struct mako_config *config);

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -51,5 +51,7 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token);
 struct mako_criteria *global_criteria(struct mako_config *config);
 ssize_t apply_each_criteria(struct wl_list *criteria_list,
 		struct mako_notification *notif);
+struct mako_criteria *create_criteria_from_notification(
+		struct mako_notification *notif, struct mako_criteria_spec *spec);
 
 #endif

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -20,6 +20,8 @@ struct mako_criteria_spec {
 	bool urgency;
 	bool category;
 	bool desktop_entry;
+	bool summary;
+	bool body;
 };
 
 struct mako_criteria {
@@ -34,10 +36,11 @@ struct mako_criteria {
 	char *app_icon;
 	bool actionable; // Whether mako_notification.actions is nonempty
 	bool expiring; // Whether mako_notification.requested_timeout is non-zero
-
 	enum mako_notification_urgency urgency;
 	char *category;
 	char *desktop_entry;
+	char *summary;
+	char *body;
 };
 
 struct mako_criteria *create_criteria(struct mako_config *config);

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -3,26 +3,12 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <wayland-client.h>
 #include "config.h"
-#include "notification.h"
+#include "types.h"
 
 struct mako_config;
-
-// Stores whether or not each field was part of the criteria specification, so
-// that, for example, "not actionable" can be distinguished from "don't care".
-// This is unnecessary for string fields, but it's best to just keep it
-// consistent.
-struct mako_criteria_spec {
-	bool app_name;
-	bool app_icon;
-	bool actionable;
-	bool expiring;
-	bool urgency;
-	bool category;
-	bool desktop_entry;
-	bool summary;
-	bool body;
-};
+struct mako_notification;
 
 struct mako_criteria {
 	struct mako_criteria_spec spec;
@@ -49,7 +35,6 @@ bool match_criteria(struct mako_criteria *criteria,
 		struct mako_notification *notif);
 
 bool parse_criteria(const char *string, struct mako_criteria *criteria);
-bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out);
 
 bool apply_criteria_field(struct mako_criteria *criteria, char *token);
 

--- a/include/notification.h
+++ b/include/notification.h
@@ -10,6 +10,7 @@
 
 struct mako_state;
 struct mako_timer;
+struct mako_criteria;
 
 struct mako_hotspot {
 	int32_t x, y;
@@ -73,5 +74,6 @@ size_t format_notification(struct mako_notification *notif, const char *format,
 void notification_handle_button(struct mako_notification *notif, uint32_t button,
 	enum wl_pointer_button_state state);
 void insert_notification(struct mako_state *state, struct mako_notification *notif);
+int group_notifications(struct mako_state *state, struct mako_criteria *criteria);
 
 #endif

--- a/include/types.h
+++ b/include/types.h
@@ -26,6 +26,26 @@ struct mako_directional {
 
 bool parse_directional(const char *string, struct mako_directional *out);
 
+// Criteria specifications are used for two things.
+// Primarily, they keep track of whether or not each field was part of the a
+// criteria specification, so that, for example, "not actionable" can be
+// distinguished from "don't care".
+// Additionally, they are used to store the set of criteria that must match for
+// notifications to group with each other.
+struct mako_criteria_spec {
+	bool app_name;
+	bool app_icon;
+	bool actionable;
+	bool expiring;
+	bool urgency;
+	bool category;
+	bool desktop_entry;
+	bool summary;
+	bool body;
+};
+
+bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out);
+
 // List of specifier characters that can appear in a format string.
 extern const char VALID_FORMAT_SPECIFIERS[];
 

--- a/notification.c
+++ b/notification.c
@@ -39,6 +39,16 @@ struct mako_notification *create_notification(struct mako_state *state) {
 	notif->id = state->last_id;
 	wl_list_init(&notif->actions);
 	notif->urgency = MAKO_NOTIFICATION_URGENCY_UNKNOWN;
+
+	// Make sure everything is a valid string so we can always compare
+	// notifications, even if they don't have a certain field.
+	notif->app_name = strdup("");
+	notif->app_icon = strdup("");
+	notif->summary = strdup("");
+	notif->body = strdup("");
+	notif->category = strdup("");
+	notif->desktop_entry = strdup("");
+
 	return notif;
 }
 

--- a/types.c
+++ b/types.c
@@ -129,6 +129,46 @@ bool parse_directional(const char *string, struct mako_directional *out) {
 	return true;
 }
 
+bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out) {
+	// Clear any existing specified fields in the output spec.
+	memset(out, 0, sizeof(struct mako_criteria_spec));
+
+	char *components = strdup(string);
+	char *saveptr = NULL;
+	char *token = strtok_r(components, ",", &saveptr);
+
+	while (token) {
+		// Can't just use &= because then we nave no way to report invalid
+		// values. :(
+		if (strcmp(token, "app-name") == 0) {
+			out->app_name = true;
+		} else if (strcmp(token, "app-icon") == 0) {
+			out->app_icon = true;
+		} else if (strcmp(token, "actionable") == 0) {
+			out->actionable = true;
+		} else if (strcmp(token, "expiring") == 0) {
+			out->expiring = true;
+		} else if (strcmp(token, "urgency") == 0) {
+			out->urgency = true;
+		} else if (strcmp(token, "category") == 0) {
+			out->category = true;
+		} else if (strcmp(token, "desktop-entry") == 0) {
+			out->desktop_entry = true;
+		} else if (strcmp(token, "summary") == 0) {
+			out->summary = true;
+		} else if (strcmp(token, "body") == 0) {
+			out->body = true;
+		} else {
+			fprintf(stderr, "Unknown criteria field '%s'\n", token);
+			return false;
+		}
+
+		token = strtok_r(NULL, ",", &saveptr);
+	}
+
+	return true;
+}
+
 bool parse_format(const char *string, char **out) {
 	size_t token_max_length = strlen(string) + 1;
 	char token[token_max_length];


### PR DESCRIPTION
Alright, part one of #66! This is not a complete solution, but I didn't want to stay silent any longer and this seemed like a good first chunk. This PR adds the following:

- Matching on the exact contents of summary and body
- Specify which criteria fields should be used for grouping notifications
- Group them when adding or removing notifications
- Re-apply criteria to all notifications that are affected by the grouping

You can use it something like this:
```
[app-name=Firefox]
group=summary
```

I was originally going to go down the path of having a first-class group type which would contain one or more notifications, and replace the list of notifications with groups on `mako_state`. This made interacting with individual notifications such a pain that I decided it would be cleaner to just re-order the list based on the grouping rules whenever it was modified.

The grouping specification reuses `mako_criteria_spec`, I've added a function to parse them from a  comma separated string. There's also now a function to create a criteria that matches a given notification, which is then used to compare them when attempting grouping. This includes matching on summary and body, but I didn't expose them as criteria because they still don't seem super useful to the user without regex support.

The current default setting is to group notifications that are identical in every way. There is no way to specify "don't group at all", but I'm planning to add that in the next chunk. I'm trying to figure out if there's a way to do it without adding a special field to `mako_criteria_spec` (since an empty spec would match everything).

As it is, when a group is created the notifications will all be pulled together within the list based on whatever sorting mode is set, but will still appear as normal notifications. The next step will be to actually allow visually combining grouped notifications. This will be accomplished by adding some new criteria that select based on a notification's index within a group (if there is one). The default will probably be to simply make the height and margins of all but the first in the group zero, and to add the number of notifications in the group to the format. Adding these criteria is why it's necessary to re-apply criteria to any newly-grouped notifications. I was hoping to avoid doing an extra criteria match, but there was no clean way to do so. Only doing it to notifications in the group seems like a reasonable trade.