### PR TITLE
Use frame scheduling when drawing frames

### DIFF
--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -19,7 +19,7 @@ static int handle_dismiss_all_notifications(sd_bus_message *msg, void *data,
 	struct mako_state *state = data;
 
 	close_all_notifications(state, MAKO_NOTIFICATION_CLOSE_DISMISSED);
-	send_frame(state);
+	set_dirty(state);
 
 	return sd_bus_reply_method_return(msg, "");
 }
@@ -35,7 +35,7 @@ static int handle_dismiss_last_notification(sd_bus_message *msg, void *data,
 	struct mako_notification *notif =
 		wl_container_of(state->notifications.next, notif, link);
 	close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
-	send_frame(state);
+	set_dirty(state);
 
 done:
 	return sd_bus_reply_method_return(msg, "");
@@ -87,7 +87,7 @@ static int handle_reload(sd_bus_message *msg, void *data,
 		apply_each_criteria(&state->config.criteria, notif);
 	}
 
-	send_frame(state);
+	set_dirty(state);
 
 	return sd_bus_reply_method_return(msg, "");
 }

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -71,7 +71,7 @@ static void handle_notification_timer(void *data) {
 	struct mako_state *state = notif->state;
 
 	close_notification(notif, MAKO_NOTIFICATION_CLOSE_EXPIRED);
-	send_frame(state);
+	set_dirty(state);
 }
 
 static int handle_notify(sd_bus_message *msg, void *data,
@@ -272,7 +272,7 @@ static int handle_notify(sd_bus_message *msg, void *data,
 	group_notifications(state, notif_criteria);
 	free(notif_criteria);
 
-	send_frame(state);
+	set_dirty(state);
 
 	return sd_bus_reply_method_return(msg, "u", notif->id);
 }
@@ -291,7 +291,7 @@ static int handle_close_notification(sd_bus_message *msg, void *data,
 	struct mako_notification *notif = get_notification(state, id);
 	if (notif) {
 		close_notification(notif, MAKO_NOTIFICATION_CLOSE_REQUEST);
-		send_frame(state);
+		set_dirty(state);
 	}
 
 	return sd_bus_reply_method_return(msg, "");

--- a/include/mako.h
+++ b/include/mako.h
@@ -36,6 +36,8 @@ struct mako_state {
 	struct zwlr_layer_surface_v1 *layer_surface;
 	struct mako_output *layer_surface_output;
 	bool configured;
+	bool frame_pending; // Have we requested a frame callback?
+	bool dirty; // Do we need to redraw?
 	int32_t scale;
 
 	int32_t width, height;

--- a/include/wayland.h
+++ b/include/wayland.h
@@ -31,6 +31,6 @@ struct mako_seat {
 
 bool init_wayland(struct mako_state *state);
 void finish_wayland(struct mako_state *state);
-void send_frame(struct mako_state *state);
+void set_dirty(struct mako_state *state);
 
 #endif


### PR DESCRIPTION
This synchronizes rendering with the vsync. This should fix "no buffer
available" errors.

Fixes https://github.com/emersion/mako/issues/70