### PR TITLE
Grouping criteria

### DIFF
--- a/config.c
+++ b/config.c
@@ -416,7 +416,7 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	} else if (strcmp(name, "ignore-timeout") == 0) {
 		return spec->ignore_timeout =
 			parse_boolean(value, &style->ignore_timeout);
-	} else if (strcmp(name, "group") == 0) {
+	} else if (strcmp(name, "group-by") == 0) {
 		return spec->group_criteria_spec =
 			parse_criteria_spec(value, &style->group_criteria_spec);
 	} else if (strcmp(name, "hidden") == 0) {
@@ -579,6 +579,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"layer", required_argument, 0, 0},
 		{"anchor", required_argument, 0, 0},
 		{"sort", required_argument, 0, 0},
+		{"group-by", required_argument, 0, 0},
 		{0},
 	};
 

--- a/config.c
+++ b/config.c
@@ -85,6 +85,7 @@ void init_default_style(struct mako_style *style) {
 	style->colors.border = 0x4C7899FF;
 
 	style->group_criteria_spec.none = true;
+	style->hidden = false;
 
 	// Everything in the default config is explicitly specified.
 	memset(&style->spec, true, sizeof(struct mako_style_spec));
@@ -201,6 +202,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 	if (style->spec.group_criteria_spec) {
 		target->group_criteria_spec = style->group_criteria_spec;
 		target->spec.group_criteria_spec = true;
+	}
+
+	if (style->spec.hidden) {
+		target->hidden = style->hidden;
+		target->spec.hidden = true;
 	}
 
 	return true;
@@ -391,6 +397,8 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	} else if (strcmp(name, "group") == 0) {
 		return spec->group_criteria_spec =
 			parse_criteria_spec(value, &style->group_criteria_spec);
+	} else if (strcmp(name, "hidden") == 0) {
+		return spec->hidden = parse_boolean(value, &style->hidden);
 	}
 
 	return false;

--- a/config.c
+++ b/config.c
@@ -23,6 +23,7 @@ void init_default_config(struct mako_config *config) {
 	wl_list_init(&config->criteria);
 	struct mako_criteria *new_criteria = create_criteria(config);
 	init_default_style(&new_criteria->style);
+	new_criteria->raw_string = strdup("(root)");
 
 	// Hide grouped notifications by default, and put the group count in
 	// their format...
@@ -34,6 +35,7 @@ void init_default_config(struct mako_config *config) {
 	new_criteria->style.spec.hidden = true;
 	new_criteria->style.format = strdup("(%g) <b>%s</b>\n%b");
 	new_criteria->style.spec.format = true;
+	new_criteria->raw_string = strdup("(default grouped)");
 
 	// ...but make the first one in the group visible.
 	new_criteria = create_criteria(config);
@@ -42,6 +44,7 @@ void init_default_config(struct mako_config *config) {
 	new_criteria->spec.group_index = true;
 	new_criteria->style.hidden = false;
 	new_criteria->style.spec.hidden = true;
+	new_criteria->raw_string = strdup("(default group-index=0)");
 
 	init_empty_style(&config->superstyle);
 

--- a/config.c
+++ b/config.c
@@ -84,8 +84,7 @@ void init_default_style(struct mako_style *style) {
 	style->colors.text = 0xFFFFFFFF;
 	style->colors.border = 0x4C7899FF;
 
-	// Only completely identical notifications should group by default.
-	memset(&style->group_criteria_spec, true, sizeof(struct mako_criteria_spec));
+	style->group_criteria_spec.none = true;
 
 	// Everything in the default config is explicitly specified.
 	memset(&style->spec, true, sizeof(struct mako_style_spec));

--- a/config.c
+++ b/config.c
@@ -31,8 +31,8 @@ void init_default_config(struct mako_config *config) {
 	init_empty_style(&new_criteria->style);
 	new_criteria->grouped = true;
 	new_criteria->spec.grouped = true;
-	new_criteria->style.hidden = true;
-	new_criteria->style.spec.hidden = true;
+	new_criteria->style.invisible = true;
+	new_criteria->style.spec.invisible = true;
 	new_criteria->style.format = strdup("(%g) <b>%s</b>\n%b");
 	new_criteria->style.spec.format = true;
 	new_criteria->raw_string = strdup("(default grouped)");
@@ -42,8 +42,8 @@ void init_default_config(struct mako_config *config) {
 	init_empty_style(&new_criteria->style);
 	new_criteria->group_index = 0;
 	new_criteria->spec.group_index = true;
-	new_criteria->style.hidden = false;
-	new_criteria->style.spec.hidden = true;
+	new_criteria->style.invisible = false;
+	new_criteria->style.spec.invisible = true;
 	new_criteria->raw_string = strdup("(default group-index=0)");
 
 	init_empty_style(&config->superstyle);
@@ -107,7 +107,7 @@ void init_default_style(struct mako_style *style) {
 	style->colors.border = 0x4C7899FF;
 
 	style->group_criteria_spec.none = true;
-	style->hidden = false;
+	style->invisible = false;
 
 	// Everything in the default config is explicitly specified.
 	memset(&style->spec, true, sizeof(struct mako_style_spec));
@@ -226,9 +226,9 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 		target->spec.group_criteria_spec = true;
 	}
 
-	if (style->spec.hidden) {
-		target->hidden = style->hidden;
-		target->spec.hidden = true;
+	if (style->spec.invisible) {
+		target->invisible = style->invisible;
+		target->spec.invisible = true;
 	}
 
 	return true;
@@ -419,8 +419,8 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	} else if (strcmp(name, "group-by") == 0) {
 		return spec->group_criteria_spec =
 			parse_criteria_spec(value, &style->group_criteria_spec);
-	} else if (strcmp(name, "hidden") == 0) {
-		return spec->hidden = parse_boolean(value, &style->hidden);
+	} else if (strcmp(name, "invisible") == 0) {
+		return spec->invisible = parse_boolean(value, &style->invisible);
 	}
 
 	return false;

--- a/config.c
+++ b/config.c
@@ -21,8 +21,27 @@ static int32_t max(int32_t a, int32_t b) {
 
 void init_default_config(struct mako_config *config) {
 	wl_list_init(&config->criteria);
-	struct mako_criteria *root_criteria = create_criteria(config);
-	init_default_style(&root_criteria->style);
+	struct mako_criteria *new_criteria = create_criteria(config);
+	init_default_style(&new_criteria->style);
+
+	// Hide grouped notifications by default, and put the group count in
+	// their format...
+	new_criteria = create_criteria(config);
+	init_empty_style(&new_criteria->style);
+	new_criteria->grouped = true;
+	new_criteria->spec.grouped = true;
+	new_criteria->style.hidden = true;
+	new_criteria->style.spec.hidden = true;
+	new_criteria->style.format = strdup("(%g) <b>%s</b>\n%b");
+	new_criteria->style.spec.format = true;
+
+	// ...but make the first one in the group visible.
+	new_criteria = create_criteria(config);
+	init_empty_style(&new_criteria->style);
+	new_criteria->group_index = 0;
+	new_criteria->spec.group_index = true;
+	new_criteria->style.hidden = false;
+	new_criteria->style.spec.hidden = true;
 
 	init_empty_style(&config->superstyle);
 

--- a/criteria.c
+++ b/criteria.c
@@ -302,9 +302,7 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token) {
 		return false;
 	}
 
-	// This should be unreachable.
-	fprintf(stderr, "Mysterious error parsing critiera field\n");
-	return false;
+	assert(false && "Criteria parser fell through");
 }
 
 // Retreive the global critiera from a given mako_config. This just so happens

--- a/criteria.c
+++ b/criteria.c
@@ -33,6 +33,7 @@ void destroy_criteria(struct mako_criteria *criteria) {
 	free(criteria->desktop_entry);
 	free(criteria->summary);
 	free(criteria->body);
+	free(criteria->raw_string);
 	free(criteria);
 }
 
@@ -189,6 +190,7 @@ bool parse_criteria(const char *string, struct mako_criteria *criteria) {
 		return false;
 	}
 
+	criteria->raw_string = strdup(string);
 	return true;
 }
 

--- a/criteria.c
+++ b/criteria.c
@@ -85,6 +85,16 @@ bool match_criteria(struct mako_criteria *criteria,
 		return false;
 	}
 
+	if (spec.group_index &&
+			criteria->group_index != notif->group_index) {
+		return false;
+	}
+
+	if (spec.grouped &&
+			criteria->grouped != (notif->group_index >= 0)) {
+		return false;
+	}
+
 	return true;
 }
 
@@ -238,6 +248,13 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token) {
 			criteria->desktop_entry = strdup(value);
 			criteria->spec.desktop_entry = true;
 			return true;
+		} else if (strcmp(key, "group_index") == 0){
+			if (!parse_int(value, &criteria->group_index)) {
+				fprintf(stderr, "Invalid group_index value '%s'", value);
+				return false;
+			}
+			criteria->spec.group_index = true;
+			return true;
 		} else {
 			// TODO: summary + body, once we support regex and they're useful.
 			// Anything left must be one of the boolean fields, defined using
@@ -260,6 +277,14 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token) {
 			return false;
 		}
 		criteria->spec.expiring = true;
+		return true;
+	} else if (strcmp(key, "grouped") == 0) {
+		if (!parse_boolean(value, &criteria->grouped)) {
+			fprintf(stderr, "Invalid value '%s' for boolean field '%s'\n",
+					value, key);
+			return false;
+		}
+		criteria->spec.grouped = true;
 		return true;
 	} else {
 		if (bare_key) {
@@ -331,6 +356,8 @@ struct mako_criteria *create_criteria_from_notification(
 	criteria->desktop_entry = strdup(notif->desktop_entry);
 	criteria->summary = strdup(notif->summary);
 	criteria->body = strdup(notif->body);
+	criteria->group_index = notif->group_index;
+	criteria->grouped = (notif->group_index >= 0);
 
 	return criteria;
 }

--- a/criteria.c
+++ b/criteria.c
@@ -248,9 +248,9 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token) {
 			criteria->desktop_entry = strdup(value);
 			criteria->spec.desktop_entry = true;
 			return true;
-		} else if (strcmp(key, "group-index") == 0){
+		} else if (strcmp(key, "group-index") == 0) {
 			if (!parse_int(value, &criteria->group_index)) {
-				fprintf(stderr, "Invalid group_index value '%s'", value);
+				fprintf(stderr, "Invalid group-index value '%s'", value);
 				return false;
 			}
 			criteria->spec.group_index = true;

--- a/criteria.c
+++ b/criteria.c
@@ -295,7 +295,9 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token) {
 		return false;
 	}
 
-	return true;
+	// This should be unreachable.
+	fprintf(stderr, "Mysterious error parsing critiera field\n");
+	return false;
 }
 
 // Retreive the global critiera from a given mako_config. This just so happens

--- a/criteria.c
+++ b/criteria.c
@@ -40,6 +40,11 @@ bool match_criteria(struct mako_criteria *criteria,
 		struct mako_notification *notif) {
 	struct mako_criteria_spec spec = criteria->spec;
 
+	if (spec.none) {
+		// `none` short-circuits all other criteria.
+		return false;
+	}
+
 	if (spec.app_name &&
 			strcmp(criteria->app_name, notif->app_name) != 0) {
 		return false;

--- a/criteria.c
+++ b/criteria.c
@@ -248,7 +248,7 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token) {
 			criteria->desktop_entry = strdup(value);
 			criteria->spec.desktop_entry = true;
 			return true;
-		} else if (strcmp(key, "group_index") == 0){
+		} else if (strcmp(key, "group-index") == 0){
 			if (!parse_int(value, &criteria->group_index)) {
 				fprintf(stderr, "Invalid group_index value '%s'", value);
 				return false;

--- a/include/config.h
+++ b/include/config.h
@@ -24,7 +24,8 @@ enum mako_sort_criteria {
 // structs are also mirrored.
 struct mako_style_spec {
 	bool width, height, margin, padding, border_size, font, markup, format,
-		 actions, default_timeout, ignore_timeout, group_criteria_spec, hidden;
+		 actions, default_timeout, ignore_timeout, group_criteria_spec,
+		 invisible;
 
 	struct {
 		bool background, text, border;
@@ -56,7 +57,7 @@ struct mako_style {
 
 	struct mako_criteria_spec group_criteria_spec;
 
-	bool hidden; // Skipped during render, doesn't count toward max_visible
+	bool invisible; // Skipped during render, doesn't count toward max_visible
 };
 
 struct mako_config {

--- a/include/config.h
+++ b/include/config.h
@@ -24,7 +24,7 @@ enum mako_sort_criteria {
 // structs are also mirrored.
 struct mako_style_spec {
 	bool width, height, margin, padding, border_size, font, markup, format,
-		 actions, default_timeout, ignore_timeout, group_criteria_spec;
+		 actions, default_timeout, ignore_timeout, group_criteria_spec, hidden;
 
 	struct {
 		bool background, text, border;
@@ -55,6 +55,8 @@ struct mako_style {
 	} colors;
 
 	struct mako_criteria_spec group_criteria_spec;
+
+	bool hidden; // Skipped during render, doesn't count toward max_visible
 };
 
 struct mako_config {

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -14,6 +14,8 @@ struct mako_criteria {
 	struct mako_criteria_spec spec;
 	struct wl_list link; // mako_config::criteria
 
+	char * raw_string; // For debugging
+
 	// Style to apply to matches:
 	struct mako_style style;
 

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -14,7 +14,7 @@ struct mako_criteria {
 	struct mako_criteria_spec spec;
 	struct wl_list link; // mako_config::criteria
 
-	char * raw_string; // For debugging
+	char *raw_string; // For debugging
 
 	// Style to apply to matches:
 	struct mako_style style;

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -20,13 +20,15 @@ struct mako_criteria {
 	// Fields that can be matched:
 	char *app_name;
 	char *app_icon;
-	bool actionable; // Whether mako_notification.actions is nonempty
-	bool expiring; // Whether mako_notification.requested_timeout is non-zero
+	bool actionable;  // Whether mako_notification.actions is nonempty
+	bool expiring;  // Whether mako_notification.requested_timeout is non-zero
 	enum mako_notification_urgency urgency;
 	char *category;
 	char *desktop_entry;
 	char *summary;
 	char *body;
+	int group_index;
+	bool grouped;  // Whether group_index is non-zero
 };
 
 struct mako_criteria *create_criteria(struct mako_config *config);

--- a/include/notification.h
+++ b/include/notification.h
@@ -24,6 +24,9 @@ struct mako_notification {
 	struct mako_style style;
 
 	uint32_t id;
+	int group_index;
+	int group_count;
+
 	char *app_name;
 	char *app_icon;
 	char *summary;

--- a/include/notification.h
+++ b/include/notification.h
@@ -56,6 +56,12 @@ enum mako_notification_close_reason {
 	MAKO_NOTIFICATION_CLOSE_UNKNOWN = 4,
 };
 
+// Tiny struct to be the data type for format_hidden_text.
+struct mako_hidden_format_data {
+	size_t hidden;
+	size_t count;
+};
+
 #define DEFAULT_ACTION_KEY "default"
 
 typedef char *(*mako_format_func_t)(char variable, bool *markup, void *data);
@@ -68,7 +74,7 @@ void close_notification(struct mako_notification *notif,
 	enum mako_notification_close_reason reason);
 void close_all_notifications(struct mako_state *state,
 	enum mako_notification_close_reason reason);
-char *format_state_text(char variable, bool *markup, void *data);
+char *format_hidden_text(char variable, bool *markup, void *data);
 char *format_notif_text(char variable, bool *markup, void *data);
 size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data);
 struct mako_notification *get_notification(struct mako_state *state, uint32_t id);

--- a/include/types.h
+++ b/include/types.h
@@ -42,6 +42,8 @@ struct mako_criteria_spec {
 	bool desktop_entry;
 	bool summary;
 	bool body;
+	bool group_index;
+	bool grouped;
 };
 
 bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out);

--- a/include/types.h
+++ b/include/types.h
@@ -44,6 +44,8 @@ struct mako_criteria_spec {
 	bool body;
 	bool group_index;
 	bool grouped;
+
+	bool none; // Special criteria that never matches, used for grouping
 };
 
 bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out);

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -238,6 +238,8 @@ specifiers.
 
 *%b*	Notification body
 
+*%g*	Number of notifications in the current group
+
 ## For the hidden notifications placeholder
 
 *%h*	Number of hidden notifications

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -122,9 +122,11 @@ dismissed with a click or via *makoctl*(1).
 
 *--format* _format_
 	Set notification format string to _format_. See *FORMAT SPECIFIERS* for
-	more information.
+	more information. To change this for grouped notifications, set it within
+	a _grouped_ criteria.
 
 	Default: <b>%s</b>\\n%b
+	Default when grouped: (%g) <b>%s</b>\\n%b
 
 *--default-timeout* _timeout_
 	Set the default timeout to _timeout_ in milliseconds. To disable the
@@ -132,9 +134,30 @@ dismissed with a click or via *makoctl*(1).
 
 	Default: 0
 
-*--ignore-timeout*
+*--ignore-timeout* 0|1
 	If set, mako will ignore the expire timeout sent by notifications and use
 	the one provided by _default-timeout_ instead.
+
+	Default: 0
+
+*--group-by* _field[,field,...]_
+	A comma-separated list of criteria fields that will be compared to other
+	visible notifications to determine if this one should form a group with
+	them. All listed criteria must be exactly equal for two notifications to
+	group.
+
+	Default: none
+
+# CRITERIA-ONLY STYLE OPTIONS
+
+Some style options are not useful in the global context and therefore have no
+associated command-line option.
+
+*invisible* 0|1
+	Whether this notification should be invisible even if it is above the
+	_max-visible_ cutoff. This is used primarily for hiding members of groups.
+	If you want to make more than the first group member visible, turn this
+	option off within a _group-index_ criteria.
 
 	Default: 0
 
@@ -175,9 +198,14 @@ The following fields are available in critiera:
 - _desktop-entry_ (string)
 - _actionable_ (boolean)
 - _expiring_ (boolean)
+- _grouped_ (boolean)
+	- Whether the notification is grouped with any others (its group-index is
+	  not -1).
+- _group-index_ (int)
+	- The notification's index within its group, or -1 if it is not grouped.
 - _hidden_ (boolean)
 	- _hidden_ is special, it defines the style for the placeholder shown when
-	  the number of notifications exceeds _max-visible_.
+	  the number of notifications or groups exceeds _max-visible_.
 
 If a field's value contains special characters, they may be escaped with a
 backslash, or quoted:
@@ -196,6 +224,16 @@ as bare words:
 	\[actionable=true\] \[actionable=1\] \[actionable\]
 
 	\[actionable=false\] \[actionable=0\] \[!actionable\]
+
+There are three criteria always present at the front of the list:
+- An empty criteria which matches all notifications and contains the defaults
+  for all style options, overwritten with any configured in the global section.
+- \[grouped\], which sets the default *format* for grouped notifications and
+  sets them *invisible*.
+- \[group-index=0\], which makes the first member of each group visible again.
+
+These options can be overridden by simply defining the criteria yourself and
+overriding them.
 
 # COLORS
 

--- a/notification.c
+++ b/notification.c
@@ -394,7 +394,7 @@ int group_notifications(struct mako_state *state, struct mako_criteria *criteria
 		}
 
 		wl_list_remove(&notif->link);
-		wl_list_insert(&matches, &notif->link);
+		wl_list_insert(matches.prev, &notif->link);
 		notif->group_index = count++;
 	}
 

--- a/notification.c
+++ b/notification.c
@@ -383,7 +383,7 @@ int group_notifications(struct mako_state *state, struct mako_criteria *criteria
 	// it makes the rest of this logic nicer.
 	struct wl_list *location = NULL;  // The place we're going to reinsert them.
 	struct mako_notification *notif = NULL, *tmp = NULL;
-	int count = 0;
+	size_t count = 0;
 	wl_list_for_each_safe(notif, tmp, &state->notifications, link) {
 		if (!match_criteria(criteria, notif)) {
 			continue;

--- a/notification.c
+++ b/notification.c
@@ -392,15 +392,15 @@ int group_notifications(struct mako_state *state, struct mako_criteria *criteria
 
 		wl_list_remove(&notif->link);
 		wl_list_insert(&matches, &notif->link);
-		notif->group_index = ++count;
+		notif->group_index = count++;
 	}
 
 	if (count == 1) {
 		// A single notification doesn't count as a group. We want to set its
-		// group_index to 0 so that we can distinguish single notifications
+		// group_index to -1 so that we can distinguish single notifications
 		// from groups in criteria. Handily, if we only matched one, we still
 		// have a pointer to it.
-		notif->group_index = 0;
+		notif->group_index = -1;
 	}
 
 	// Now we need to rematch criteria for all of the grouped notifications,

--- a/notification.c
+++ b/notification.c
@@ -380,6 +380,7 @@ int group_notifications(struct mako_state *state, struct mako_criteria *criteria
 	// it makes the rest of this logic nicer.
 	struct wl_list *location = NULL;  // The place we're going to reinsert them.
 	struct mako_notification *notif, *tmp;
+	int count = 0;
 	wl_list_for_each_safe(notif, tmp, &state->notifications, link) {
 		if (!match_criteria(criteria, notif)) {
 			continue;
@@ -391,11 +392,28 @@ int group_notifications(struct mako_state *state, struct mako_criteria *criteria
 
 		wl_list_remove(&notif->link);
 		wl_list_insert(&matches, &notif->link);
+		notif->group_index = ++count;
+	}
+
+	if (count == 1) {
+		// A single notification doesn't count as a group. We want to set its
+		// group_index to 0 so that we can distinguish single notifications
+		// from groups in criteria. Handily, if we only matched one, we still
+		// have a pointer to it.
+		notif->group_index = 0;
 	}
 
 	// Now we need to rematch criteria for all of the grouped notifications,
-	// in case it changes their styles.
+	// in case it changes their styles. We also take this opportunity to record
+	// the total number of notifications in the group, so that it can be used
+	// in the notifications' format.
+	// We can't skip this even if there was only a single match, as we may be
+	// removing the second-to-last notification of a group, and still need to
+	// potentially change style now that the matched one isn't in a group
+	// anymore.
 	wl_list_for_each(notif, &matches, link) {
+		notif->group_count = count;
+
 		int rematch_count = apply_each_criteria(&state->config.criteria, notif);
 		if (rematch_count == -1) {
 			// We encountered an allocation failure or similar while applying
@@ -410,8 +428,6 @@ int group_notifications(struct mako_state *state, struct mako_criteria *criteria
 			return -1;
 		}
 	}
-
-	int count = wl_list_length(&matches);
 
 	// Place all of the matches back into the list where the first one was
 	// originally.

--- a/notification.c
+++ b/notification.c
@@ -49,6 +49,9 @@ struct mako_notification *create_notification(struct mako_state *state) {
 	notif->category = strdup("");
 	notif->desktop_entry = strdup("");
 
+	// Start ungrouped.
+	notif->group_index = -1;
+
 	return notif;
 }
 

--- a/notification.c
+++ b/notification.c
@@ -213,6 +213,8 @@ char *format_notif_text(char variable, bool *markup, void *data) {
 	case 'b':
 		*markup = notif->style.markup;
 		return strdup(notif->body);
+	case 'g':
+		return mako_asprintf("%d", notif->group_count);
 	}
 	return NULL;
 }

--- a/notification.c
+++ b/notification.c
@@ -190,15 +190,13 @@ static char *mako_asprintf(const char *fmt, ...) {
 
 // Any new format specifiers must also be added to VALID_FORMAT_SPECIFIERS.
 
-char *format_state_text(char variable, bool *markup, void *data) {
-	struct mako_state *state = data;
+char *format_hidden_text(char variable, bool *markup, void *data) {
+	struct mako_hidden_format_data *format_data = data;
 	switch (variable) {
-	case 'h':;
-		int hidden = wl_list_length(&state->notifications) - state->config.max_visible;
-		return mako_asprintf("%d", hidden);
-	case 't':;
-		int count = wl_list_length(&state->notifications);
-		return mako_asprintf("%d", count);
+	case 'h':
+		return mako_asprintf("%d", format_data->hidden);
+	case 't':
+		return mako_asprintf("%d", format_data->count);
 	}
 	return NULL;
 }

--- a/notification.c
+++ b/notification.c
@@ -398,11 +398,17 @@ int group_notifications(struct mako_state *state, struct mako_criteria *criteria
 		notif->group_index = count++;
 	}
 
+	// If count is zero, we don't need to worry about changing anything. The
+	// notification's style has its grouping critiera set to none.
+
 	if (count == 1) {
-		// A single notification doesn't count as a group. We want to set its
-		// group_index to -1 so that we can distinguish single notifications
-		// from groups in criteria. Handily, if we only matched one, we still
-		// have a pointer to it.
+		// If we matched a single notification, it means that it has grouping
+		// criteria set, but didn't have any others to group with. This makes
+		// it ungrouped just as if it had no grouping criteria. If this is a
+		// new notification, its index is already set to -1. However, this also
+		// happens when a notification had been part of a group and all the
+		// others have closed, so we need to set it anyway. Handily, if we only
+		// matched one, we still have a pointer to it.
 		notif->group_index = -1;
 	}
 

--- a/notification.c
+++ b/notification.c
@@ -382,7 +382,7 @@ int group_notifications(struct mako_state *state, struct mako_criteria *criteria
 	// is technically unnecessary, since it will go back in the same place, but
 	// it makes the rest of this logic nicer.
 	struct wl_list *location = NULL;  // The place we're going to reinsert them.
-	struct mako_notification *notif, *tmp;
+	struct mako_notification *notif = NULL, *tmp = NULL;
 	int count = 0;
 	wl_list_for_each_safe(notif, tmp, &state->notifications, link) {
 		if (!match_criteria(criteria, notif)) {
@@ -407,8 +407,9 @@ int group_notifications(struct mako_state *state, struct mako_criteria *criteria
 		// it ungrouped just as if it had no grouping criteria. If this is a
 		// new notification, its index is already set to -1. However, this also
 		// happens when a notification had been part of a group and all the
-		// others have closed, so we need to set it anyway. Handily, if we only
-		// matched one, we still have a pointer to it.
+		// others have closed, so we need to set it anyway.
+		// We can't use the current pointer, wl_list_for_each_safe clobbers it.
+		notif = wl_container_of(matches.prev, notif, link);
 		notif->group_index = -1;
 	}
 

--- a/render.c
+++ b/render.c
@@ -205,7 +205,7 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 
 		++i; // We count how many we've seen even if we're not rendering them.
 
-		if (style->hidden) {
+		if (style->invisible) {
 			continue;
 		}
 

--- a/types.c
+++ b/types.c
@@ -158,6 +158,8 @@ bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out) {
 			out->summary = true;
 		} else if (strcmp(token, "body") == 0) {
 			out->body = true;
+		} else if (strcmp(token, "none") == 0) {
+			out->none = true;
 		} else {
 			fprintf(stderr, "Unknown criteria field '%s'\n", token);
 			return false;

--- a/types.c
+++ b/types.c
@@ -14,7 +14,7 @@
 #include "types.h"
 
 
-const char VALID_FORMAT_SPECIFIERS[] = "%asbht";
+const char VALID_FORMAT_SPECIFIERS[] = "%asbhtg";
 
 
 bool parse_boolean(const char *string, bool *out) {


### PR DESCRIPTION
Part 2 of 2! Closes #66. Also makes unicorns real.

Actual features:
- Renamed `group` to `group-by` and made it available on the cli.
- Grouping defaults to the new `none` criteria spec which never matches any notifications. This cannot be used in criteria sections because it would just be a fancy comment.
- Add an `invisible` style option to skip rendering arbitrary notifications. This is not exposed on the cli as it would make mako fairly useless. Maybe after we add history?
- Add %g format specifier for the group size.
- Inserts two new default criteria into the list:
    - Set the format of all grouped notifications to include the group size and make them invisible.
    - Re-visibilize the first one in the group.
- Groups count as a single notification when figuring out which ones to hide after `max-visible`.

Bonus feature:
- Store the raw criteria strings on criteria like sway does so they're available for easy reading when debugging.

Known issues:
- If multiple notifications per group are configured to be visible, only the first will be visible anyway when it is directly before the `max-visible` cutoff. I'm just going to file an issue for this since I don't expect many people to run into it.

Testing done:
- Lots, also probably not enough.
- Priority sorting still seems to work correctly, which I was worried about breaking.
- Did a bunch of reconfiguration stress testing to make sure things regrouped correctly and nothing exploded.

Things not done:
- I punted on converting `hidden` to a group. It's really hard to count the number of notifications outside of render. I still think this can be done, but it will take some more thought.
- I didn't end up adding a greater-than operator for criteria. I have it written, but it was getting complicated enough on its own that I left it out.