### PR TITLE
Return the same id when replacing a notification

### DIFF
--- a/include/notification.h
+++ b/include/notification.h
@@ -60,8 +60,10 @@ typedef char *(*mako_format_func_t)(char variable, bool *markup, void *data);
 
 bool hotspot_at(struct mako_hotspot *hotspot, int32_t x, int32_t y);
 
+void reset_notification(struct mako_notification *notif);
 struct mako_notification *create_notification(struct mako_state *state);
 void destroy_notification(struct mako_notification *notif);
+
 void close_notification(struct mako_notification *notif,
 	enum mako_notification_close_reason reason);
 void close_all_notifications(struct mako_state *state,

--- a/notification.c
+++ b/notification.c
@@ -36,7 +36,9 @@ void reset_notification(struct mako_notification *notif) {
 
 	notif->urgency = MAKO_NOTIFICATION_URGENCY_UNKNOWN;
 	notif->progress = -1;
+
 	destroy_timer(notif->timer);
+	notif->timer = NULL;
 
 	free(notif->app_name);
 	free(notif->app_icon);
@@ -44,6 +46,13 @@ void reset_notification(struct mako_notification *notif) {
 	free(notif->body);
 	free(notif->category);
 	free(notif->desktop_entry);
+
+	notif->app_name = NULL;
+	notif->app_icon = NULL;
+	notif->summary = NULL;
+	notif->body = NULL;
+	notif->category = NULL;
+	notif->desktop_entry = NULL;
 }
 
 struct mako_notification *create_notification(struct mako_state *state) {


### PR DESCRIPTION
This adds `reset_notification` and uses it to... reset the notification. Instead of closing and creating a new one, we put all of the new info into the old container so it retains its id and position in the list.

Fixes #113.