### PR TITLE
Partial icon support

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -6,6 +6,7 @@ packages:
   - cairo
   - pango
   - gdk-pixbuf2
+  - gtk3
   - systemd
 sources:
   - https://github.com/emersion/mako

--- a/.build.yml
+++ b/.build.yml
@@ -5,6 +5,7 @@ packages:
   - wayland-protocols
   - cairo
   - pango
+  - gdk-pixbuf2
   - systemd
 sources:
   - https://github.com/emersion/mako

--- a/config.c
+++ b/config.c
@@ -94,6 +94,8 @@ void init_default_style(struct mako_style *style) {
 
 	style->border_size = 2;
 
+	style->max_icon_size = 64;
+
 	style->font = strdup("monospace 10");
 	style->markup = true;
 	style->format = strdup("<b>%s</b>\n%b");
@@ -176,6 +178,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 		target->spec.border_size = true;
 	}
 
+	if (style->spec.max_icon_size) {
+		target->max_icon_size = style->max_icon_size;
+		target->spec.max_icon_size = true;
+	}
+
 	if (style->spec.font) {
 		free(target->font);
 		target->font = new_font;
@@ -254,6 +261,7 @@ bool apply_superset_style(
 	target->spec.margin = true;
 	target->spec.padding = true;
 	target->spec.border_size = true;
+	target->spec.max_icon_size = true;
 	target->spec.default_timeout = true;
 	target->spec.markup = true;
 	target->spec.actions = true;
@@ -287,6 +295,7 @@ bool apply_superset_style(
 			max(style->padding.bottom, target->padding.bottom);
 		target->padding.left = max(style->padding.left, target->padding.left);
 		target->border_size = max(style->border_size, target->border_size);
+		target->max_icon_size = max(style->max_icon_size, target->max_icon_size);
 		target->default_timeout =
 			max(style->default_timeout, target->default_timeout);
 
@@ -412,6 +421,9 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		return spec->colors.border = parse_color(value, &style->colors.border);
 	} else if (strcmp(name, "progress-color") == 0) {
 		return spec->colors.progress = parse_mako_color(value, &style->colors.progress);
+	} else if (strcmp(name, "max-icon-size") == 0) {
+		return spec->max_icon_size =
+			parse_int(value, &style->max_icon_size);
 	} else if (strcmp(name, "markup") == 0) {
 		return spec->markup = parse_boolean(value, &style->markup);
 	} else if (strcmp(name, "actions") == 0) {
@@ -579,6 +591,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"border-size", required_argument, 0, 0},
 		{"border-color", required_argument, 0, 0},
 		{"progress-color", required_argument, 0, 0},
+		{"max-icon-size", required_argument, 0, 0},
 		{"markup", required_argument, 0, 0},
 		{"actions", required_argument, 0, 0},
 		{"format", required_argument, 0, 0},

--- a/config.c
+++ b/config.c
@@ -94,8 +94,13 @@ void init_default_style(struct mako_style *style) {
 
 	style->border_size = 2;
 
+#ifdef HAVE_ICONS
 	style->icons = true;
+#else
+	style->icons = false;
+#endif
 	style->max_icon_size = 64;
+
 
 	style->font = strdup("monospace 10");
 	style->markup = true;
@@ -302,7 +307,7 @@ bool apply_superset_style(
 			max(style->padding.bottom, target->padding.bottom);
 		target->padding.left = max(style->padding.left, target->padding.left);
 		target->border_size = max(style->border_size, target->border_size);
-		target->icons = style->max_icon_size || target->max_icon_size;
+		target->icons = style->icons || target->icons;
 		target->max_icon_size = max(style->max_icon_size, target->max_icon_size);
 		target->default_timeout =
 			max(style->default_timeout, target->default_timeout);
@@ -430,8 +435,13 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	} else if (strcmp(name, "progress-color") == 0) {
 		return spec->colors.progress = parse_mako_color(value, &style->colors.progress);
 	} else if (strcmp(name, "icons") == 0) {
+#ifdef HAVE_ICONS
 		return spec->icons =
 			parse_boolean(value, &style->icons);
+#else
+		fprintf(stderr, "Icon support not built in, ignoring icons setting.\n");
+		return true;
+#endif
 	} else if (strcmp(name, "max-icon-size") == 0) {
 		return spec->max_icon_size =
 			parse_int(value, &style->max_icon_size);

--- a/config.c
+++ b/config.c
@@ -94,6 +94,7 @@ void init_default_style(struct mako_style *style) {
 
 	style->border_size = 2;
 
+	style->show_icons = true;
 	style->max_icon_size = 64;
 
 	style->font = strdup("monospace 10");
@@ -176,6 +177,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 	if (style->spec.border_size) {
 		target->border_size = style->border_size;
 		target->spec.border_size = true;
+	}
+
+	if (style->spec.show_icons) {
+		target->show_icons = style->show_icons;
+		target->spec.show_icons = true;
 	}
 
 	if (style->spec.max_icon_size) {
@@ -261,6 +267,7 @@ bool apply_superset_style(
 	target->spec.margin = true;
 	target->spec.padding = true;
 	target->spec.border_size = true;
+	target->spec.show_icons = true;
 	target->spec.max_icon_size = true;
 	target->spec.default_timeout = true;
 	target->spec.markup = true;
@@ -295,6 +302,7 @@ bool apply_superset_style(
 			max(style->padding.bottom, target->padding.bottom);
 		target->padding.left = max(style->padding.left, target->padding.left);
 		target->border_size = max(style->border_size, target->border_size);
+		target->show_icons = style->max_icon_size || target->max_icon_size;
 		target->max_icon_size = max(style->max_icon_size, target->max_icon_size);
 		target->default_timeout =
 			max(style->default_timeout, target->default_timeout);
@@ -421,6 +429,9 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		return spec->colors.border = parse_color(value, &style->colors.border);
 	} else if (strcmp(name, "progress-color") == 0) {
 		return spec->colors.progress = parse_mako_color(value, &style->colors.progress);
+	} else if (strcmp(name, "show-icons") == 0) {
+		return spec->show_icons =
+			parse_boolean(value, &style->show_icons);
 	} else if (strcmp(name, "max-icon-size") == 0) {
 		return spec->max_icon_size =
 			parse_int(value, &style->max_icon_size);
@@ -591,6 +602,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"border-size", required_argument, 0, 0},
 		{"border-color", required_argument, 0, 0},
 		{"progress-color", required_argument, 0, 0},
+		{"show-icons", required_argument, 0, 0},
 		{"max-icon-size", required_argument, 0, 0},
 		{"markup", required_argument, 0, 0},
 		{"actions", required_argument, 0, 0},

--- a/config.c
+++ b/config.c
@@ -94,7 +94,7 @@ void init_default_style(struct mako_style *style) {
 
 	style->border_size = 2;
 
-	style->show_icons = true;
+	style->icons = true;
 	style->max_icon_size = 64;
 
 	style->font = strdup("monospace 10");
@@ -179,9 +179,9 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 		target->spec.border_size = true;
 	}
 
-	if (style->spec.show_icons) {
-		target->show_icons = style->show_icons;
-		target->spec.show_icons = true;
+	if (style->spec.icons) {
+		target->icons = style->icons;
+		target->spec.icons = true;
 	}
 
 	if (style->spec.max_icon_size) {
@@ -267,7 +267,7 @@ bool apply_superset_style(
 	target->spec.margin = true;
 	target->spec.padding = true;
 	target->spec.border_size = true;
-	target->spec.show_icons = true;
+	target->spec.icons = true;
 	target->spec.max_icon_size = true;
 	target->spec.default_timeout = true;
 	target->spec.markup = true;
@@ -302,7 +302,7 @@ bool apply_superset_style(
 			max(style->padding.bottom, target->padding.bottom);
 		target->padding.left = max(style->padding.left, target->padding.left);
 		target->border_size = max(style->border_size, target->border_size);
-		target->show_icons = style->max_icon_size || target->max_icon_size;
+		target->icons = style->max_icon_size || target->max_icon_size;
 		target->max_icon_size = max(style->max_icon_size, target->max_icon_size);
 		target->default_timeout =
 			max(style->default_timeout, target->default_timeout);
@@ -429,9 +429,9 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		return spec->colors.border = parse_color(value, &style->colors.border);
 	} else if (strcmp(name, "progress-color") == 0) {
 		return spec->colors.progress = parse_mako_color(value, &style->colors.progress);
-	} else if (strcmp(name, "show-icons") == 0) {
-		return spec->show_icons =
-			parse_boolean(value, &style->show_icons);
+	} else if (strcmp(name, "icons") == 0) {
+		return spec->icons =
+			parse_boolean(value, &style->icons);
 	} else if (strcmp(name, "max-icon-size") == 0) {
 		return spec->max_icon_size =
 			parse_int(value, &style->max_icon_size);
@@ -602,7 +602,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"border-size", required_argument, 0, 0},
 		{"border-color", required_argument, 0, 0},
 		{"progress-color", required_argument, 0, 0},
-		{"show-icons", required_argument, 0, 0},
+		{"icons", required_argument, 0, 0},
 		{"max-icon-size", required_argument, 0, 0},
 		{"markup", required_argument, 0, 0},
 		{"actions", required_argument, 0, 0},

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -52,6 +52,13 @@ static int handle_get_capabilities(sd_bus_message *msg, void *data,
 		}
 	}
 
+	if (state->config.superstyle.icons) {
+		ret = sd_bus_message_append(reply, "s", "icon-static");
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
 	ret = sd_bus_message_close_container(reply);
 	if (ret < 0) {
 		return ret;

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -11,6 +11,8 @@
 #include "notification.h"
 #include "wayland.h"
 
+#include "icon.h"
+
 static const char *service_path = "/org/freedesktop/Notifications";
 static const char *service_interface = "org.freedesktop.Notifications";
 
@@ -109,6 +111,7 @@ static int handle_notify(sd_bus_message *msg, void *data,
 	notif->app_icon = strdup(app_icon);
 	notif->summary = strdup(summary);
 	notif->body = strdup(body);
+	notif->icon = create_icon(notif->app_icon, state->config.superstyle.max_icon_size);
 
 	// These fields may not be filled, so make sure they're valid strings.
 	notif->category = strdup("");

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -111,7 +111,9 @@ static int handle_notify(sd_bus_message *msg, void *data,
 	notif->app_icon = strdup(app_icon);
 	notif->summary = strdup(summary);
 	notif->body = strdup(body);
-	notif->icon = create_icon(notif->app_icon, state->config.superstyle.max_icon_size);
+	if (state->config.superstyle.icons) {
+		notif->icon = create_icon(notif->app_icon, state->config.superstyle.max_icon_size);
+	}
 
 	// These fields may not be filled, so make sure they're valid strings.
 	notif->category = strdup("");

--- a/icon.c
+++ b/icon.c
@@ -1,137 +1,34 @@
 #include <stdio.h>
 #include <assert.h>
 #include <cairo/cairo.h>
-#include <gdk-pixbuf/gdk-pixbuf.h>
 
 #include "icon.h"
 
-cairo_surface_t* gdk_cairo_image_surface_create_from_pixbuf(const GdkPixbuf *gdkbuf) {
-	int chan = gdk_pixbuf_get_n_channels(gdkbuf);
-	if (chan < 3) {
-		return NULL;
-	}
+#ifdef SHOW_ICONS
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
 
-	const guint8* gdkpix = gdk_pixbuf_read_pixels(gdkbuf);
-	if (!gdkpix) {
-		return NULL;
-	}
-	gint w = gdk_pixbuf_get_width(gdkbuf);
-	gint h = gdk_pixbuf_get_height(gdkbuf);
-	int stride = gdk_pixbuf_get_rowstride(gdkbuf);
-
-	cairo_format_t fmt = (chan == 3) ? CAIRO_FORMAT_RGB24 : CAIRO_FORMAT_ARGB32;
-	cairo_surface_t * cs = cairo_image_surface_create (fmt, w, h);
-	cairo_surface_flush (cs);
-	if ( !cs || cairo_surface_status(cs) != CAIRO_STATUS_SUCCESS) {
-		return NULL;
-	}
-
-	int cstride = cairo_image_surface_get_stride(cs);
-	unsigned char * cpix = cairo_image_surface_get_data(cs);
-
-	if (chan == 3) {
-		int i;
-		for (i = h; i; --i) {
-			const guint8 *gp = gdkpix;
-			unsigned char *cp = cpix;
-			const guint8* end = gp + 3*w;
-			while (gp < end) {
-#if G_BYTE_ORDER == G_LITTLE_ENDIAN
-				cp[0] = gp[2];
-				cp[1] = gp[1];
-				cp[2] = gp[0];
-#else
-				cp[1] = gp[0];
-				cp[2] = gp[1];
-				cp[3] = gp[2];
-#endif
-				gp += 3;
-				cp += 4;
-			}
-			gdkpix += stride;
-			cpix += cstride;
-		}
-	} else {
-		/* premul-color = alpha/255 * color/255 * 255 = (alpha*color)/255
-		 * (z/255) = z/256 * 256/255     = z/256 (1 + 1/255)
-		 *         = z/256 + (z/256)/255 = (z + z/255)/256
-		 *         # recurse once
-		 *         = (z + (z + z/255)/256)/256
-		 *         = (z + z/256 + z/256/255) / 256
-		 *         # only use 16bit uint operations, loose some precision,
-		 *         # result is floored.
-		 *       ->  (z + z>>8)>>8
-		 *         # add 0x80/255 = 0.5 to convert floor to round
-		 *       =>  (z+0x80 + (z+0x80)>>8 ) >> 8
-		 * ------
-		 * tested as equal to lround(z/255.0) for uint z in [0..0xfe02]
-		 */
-#define PREMUL_ALPHA(x,a,b,z) \
-		G_STMT_START { z = a * b + 0x80; x = (z + (z >> 8)) >> 8; } \
-		G_STMT_END
-		int i;
-		for (i = h; i; --i) {
-			const guint8 *gp = gdkpix;
-			unsigned char *cp = cpix;
-			const guint8* end = gp + 4*w;
-			guint z1, z2, z3;
-			while (gp < end) {
-#if G_BYTE_ORDER == G_LITTLE_ENDIAN
-				PREMUL_ALPHA(cp[0], gp[2], gp[3], z1);
-				PREMUL_ALPHA(cp[1], gp[1], gp[3], z2);
-				PREMUL_ALPHA(cp[2], gp[0], gp[3], z3);
-				cp[3] = gp[3];
-#else
-				PREMUL_ALPHA(cp[1], gp[0], gp[3], z1);
-				PREMUL_ALPHA(cp[2], gp[1], gp[3], z2);
-				PREMUL_ALPHA(cp[3], gp[2], gp[3], z3);
-				cp[0] = gp[3];
-#endif
-				gp += 4;
-				cp += 4;
-			}
-			gdkpix += stride;
-			cpix += cstride;
-		}
-#undef PREMUL_ALPHA
-	}
-	cairo_surface_mark_dirty(cs);
-	return cs;
-}
-
-cairo_surface_t *load_icon(const char *path) {
+GdkPixbuf *load_image(const char *path) {
 	if (strlen(path) == 0) {
 		return NULL;
 	}
-	cairo_surface_t *image;
 	GError *err = NULL;
 	GdkPixbuf *pixbuf = gdk_pixbuf_new_from_file(path, &err);
 	if (!pixbuf) {
 		fprintf(stderr, "Failed to load icon (%s)\n", err->message);
 		return NULL;
 	}
-	image = gdk_cairo_image_surface_create_from_pixbuf(pixbuf);
-	g_object_unref(pixbuf);
-	if (!image) {
-		fprintf(stderr, "Failed to read icon\n");
-		return NULL;
-	}
-	if (cairo_surface_status(image) != CAIRO_STATUS_SUCCESS) {
-		fprintf(stderr, "Failed to read icon: %s\n",
-				cairo_status_to_string(cairo_surface_status(image)));
-		return NULL;
-	}
-	return image;
+	return pixbuf;
 }
 
 struct mako_icon get_icon(const char *path, double max_size) {
 	struct mako_icon icon;
-	icon.image = load_icon(path);
+	icon.image = load_image(path);
 	if (icon.image == NULL)
 		return icon;
 
-	icon.image_width = cairo_image_surface_get_width(icon.image);
-	icon.image_height = cairo_image_surface_get_height(icon.image);
+	icon.image_width = gdk_pixbuf_get_width(icon.image);
+	icon.image_height = gdk_pixbuf_get_height(icon.image);
 
 	if (icon.image_width > icon.image_height) {
 		// Width limits size
@@ -155,7 +52,35 @@ struct mako_icon get_icon(const char *path, double max_size) {
 		}
 	}
 
-	//printf("%f %f %f %f\n", icon.width, icon.height, icon.image_width, icon.image_height);
-
 	return icon;
 }
+
+void draw_icon(cairo_t *cairo, struct mako_icon icon,
+		double xpos, double ypos, double scale) {
+	cairo_save(cairo);
+	cairo_scale(cairo, icon.scale * scale, icon.scale * scale);
+	gdk_cairo_set_source_pixbuf(cairo, icon.image, xpos / icon.scale, ypos / icon.scale);
+	cairo_paint(cairo);
+	cairo_restore(cairo);
+}
+
+void destroy_icon(struct mako_icon icon) {
+	if (icon.image !=  NULL) {
+		g_object_unref(icon.image);
+	}
+}
+
+#else
+
+struct mako_icon get_icon(const char *path, double max_size) {
+	struct mako_icon icon;
+	icon.image = NULL;
+	return icon;
+}
+
+void draw_icon(cairo_t *cairo, struct mako_icon icon,
+		double xpos, double ypos, double scale) {}
+
+void destroy_icon(struct mako_icon icon) {}
+#endif
+

--- a/icon.c
+++ b/icon.c
@@ -1,12 +1,10 @@
 #include <stdio.h>
 #include <assert.h>
 #include <cairo/cairo.h>
-
-#include "icon.h"
-
-#ifdef SHOW_ICONS
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gdk/gdk.h>
+
+#include "icon.h"
 
 GdkPixbuf *load_image(const char *path) {
 	if (strlen(path) == 0) {
@@ -69,18 +67,3 @@ void destroy_icon(struct mako_icon icon) {
 		g_object_unref(icon.image);
 	}
 }
-
-#else
-
-struct mako_icon get_icon(const char *path, double max_size) {
-	struct mako_icon icon;
-	icon.image = NULL;
-	return icon;
-}
-
-void draw_icon(cairo_t *cairo, struct mako_icon icon,
-		double xpos, double ypos, double scale) {}
-
-void destroy_icon(struct mako_icon icon) {}
-#endif
-

--- a/icon.c
+++ b/icon.c
@@ -27,16 +27,6 @@ double fit_to_square(int width, int height, int square_size) {
 	return longest > square_size ? square_size/longest : 1.0;
 }
 
-void set_icon_image(struct mako_icon *icon, GdkPixbuf *image) {
-	icon->image =
-		cairo_image_surface_create(CAIRO_FORMAT_ARGB32, icon->width, icon->height);
-	cairo_t *cairo = cairo_create(icon->image);
-	cairo_scale(cairo, icon->scale, icon->scale);
-	gdk_cairo_set_source_pixbuf(cairo, image, 0, 0);
-	cairo_paint(cairo);
-	cairo_destroy(cairo);
-}
-
 struct mako_icon *create_icon(const char *path, double max_size) {
 	GdkPixbuf *image = load_image(path);
 	if (image == NULL) {
@@ -49,7 +39,13 @@ struct mako_icon *create_icon(const char *path, double max_size) {
 	icon->scale = fit_to_square(image_width, image_height, max_size);
 	icon->width = image_width * icon->scale;
 	icon->height = image_height * icon->scale;
-	set_icon_image(icon, image);
+
+	icon->image =
+		cairo_image_surface_create(CAIRO_FORMAT_ARGB32, image_width, image_height);
+	cairo_t *cairo = cairo_create(icon->image);
+	gdk_cairo_set_source_pixbuf(cairo, image, 0, 0);
+	cairo_paint(cairo);
+	cairo_destroy(cairo);
 
 	g_object_unref(image);
 
@@ -64,8 +60,8 @@ struct mako_icon *create_icon(const char *path, double max_size) {
 void draw_icon(cairo_t *cairo, struct mako_icon *icon,
 		double xpos, double ypos, double scale) {
 	cairo_save(cairo);
-	cairo_scale(cairo, scale, scale);
-	cairo_set_source_surface(cairo, icon->image, xpos, ypos);
+	cairo_scale(cairo, scale*icon->scale, scale*icon->scale);
+	cairo_set_source_surface(cairo, icon->image, xpos/icon->scale, ypos/icon->scale);
 	cairo_paint(cairo);
 	cairo_restore(cairo);
 }

--- a/icon.c
+++ b/icon.c
@@ -19,7 +19,7 @@ GdkPixbuf *load_image(const char *path) {
 	return pixbuf;
 }
 
-struct mako_icon get_icon(const char *path, double max_size) {
+struct mako_icon create_icon(const char *path, double max_size) {
 	struct mako_icon icon;
 	icon.image = load_image(path);
 	if (icon.image == NULL)

--- a/icon.c
+++ b/icon.c
@@ -1,0 +1,161 @@
+#include <stdio.h>
+#include <assert.h>
+#include <cairo/cairo.h>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+
+#include "icon.h"
+
+cairo_surface_t* gdk_cairo_image_surface_create_from_pixbuf(const GdkPixbuf *gdkbuf) {
+	int chan = gdk_pixbuf_get_n_channels(gdkbuf);
+	if (chan < 3) {
+		return NULL;
+	}
+
+	const guint8* gdkpix = gdk_pixbuf_read_pixels(gdkbuf);
+	if (!gdkpix) {
+		return NULL;
+	}
+	gint w = gdk_pixbuf_get_width(gdkbuf);
+	gint h = gdk_pixbuf_get_height(gdkbuf);
+	int stride = gdk_pixbuf_get_rowstride(gdkbuf);
+
+	cairo_format_t fmt = (chan == 3) ? CAIRO_FORMAT_RGB24 : CAIRO_FORMAT_ARGB32;
+	cairo_surface_t * cs = cairo_image_surface_create (fmt, w, h);
+	cairo_surface_flush (cs);
+	if ( !cs || cairo_surface_status(cs) != CAIRO_STATUS_SUCCESS) {
+		return NULL;
+	}
+
+	int cstride = cairo_image_surface_get_stride(cs);
+	unsigned char * cpix = cairo_image_surface_get_data(cs);
+
+	if (chan == 3) {
+		int i;
+		for (i = h; i; --i) {
+			const guint8 *gp = gdkpix;
+			unsigned char *cp = cpix;
+			const guint8* end = gp + 3*w;
+			while (gp < end) {
+#if G_BYTE_ORDER == G_LITTLE_ENDIAN
+				cp[0] = gp[2];
+				cp[1] = gp[1];
+				cp[2] = gp[0];
+#else
+				cp[1] = gp[0];
+				cp[2] = gp[1];
+				cp[3] = gp[2];
+#endif
+				gp += 3;
+				cp += 4;
+			}
+			gdkpix += stride;
+			cpix += cstride;
+		}
+	} else {
+		/* premul-color = alpha/255 * color/255 * 255 = (alpha*color)/255
+		 * (z/255) = z/256 * 256/255     = z/256 (1 + 1/255)
+		 *         = z/256 + (z/256)/255 = (z + z/255)/256
+		 *         # recurse once
+		 *         = (z + (z + z/255)/256)/256
+		 *         = (z + z/256 + z/256/255) / 256
+		 *         # only use 16bit uint operations, loose some precision,
+		 *         # result is floored.
+		 *       ->  (z + z>>8)>>8
+		 *         # add 0x80/255 = 0.5 to convert floor to round
+		 *       =>  (z+0x80 + (z+0x80)>>8 ) >> 8
+		 * ------
+		 * tested as equal to lround(z/255.0) for uint z in [0..0xfe02]
+		 */
+#define PREMUL_ALPHA(x,a,b,z) \
+		G_STMT_START { z = a * b + 0x80; x = (z + (z >> 8)) >> 8; } \
+		G_STMT_END
+		int i;
+		for (i = h; i; --i) {
+			const guint8 *gp = gdkpix;
+			unsigned char *cp = cpix;
+			const guint8* end = gp + 4*w;
+			guint z1, z2, z3;
+			while (gp < end) {
+#if G_BYTE_ORDER == G_LITTLE_ENDIAN
+				PREMUL_ALPHA(cp[0], gp[2], gp[3], z1);
+				PREMUL_ALPHA(cp[1], gp[1], gp[3], z2);
+				PREMUL_ALPHA(cp[2], gp[0], gp[3], z3);
+				cp[3] = gp[3];
+#else
+				PREMUL_ALPHA(cp[1], gp[0], gp[3], z1);
+				PREMUL_ALPHA(cp[2], gp[1], gp[3], z2);
+				PREMUL_ALPHA(cp[3], gp[2], gp[3], z3);
+				cp[0] = gp[3];
+#endif
+				gp += 4;
+				cp += 4;
+			}
+			gdkpix += stride;
+			cpix += cstride;
+		}
+#undef PREMUL_ALPHA
+	}
+	cairo_surface_mark_dirty(cs);
+	return cs;
+}
+
+cairo_surface_t *load_icon(const char *path) {
+	if (strlen(path) == 0) {
+		return NULL;
+	}
+	cairo_surface_t *image;
+	GError *err = NULL;
+	GdkPixbuf *pixbuf = gdk_pixbuf_new_from_file(path, &err);
+	if (!pixbuf) {
+		fprintf(stderr, "Failed to load icon (%s)\n", err->message);
+		return NULL;
+	}
+	image = gdk_cairo_image_surface_create_from_pixbuf(pixbuf);
+	g_object_unref(pixbuf);
+	if (!image) {
+		fprintf(stderr, "Failed to read icon\n");
+		return NULL;
+	}
+	if (cairo_surface_status(image) != CAIRO_STATUS_SUCCESS) {
+		fprintf(stderr, "Failed to read icon: %s\n",
+				cairo_status_to_string(cairo_surface_status(image)));
+		return NULL;
+	}
+	return image;
+}
+
+struct mako_icon get_icon(const char *path, double max_size) {
+	struct mako_icon icon;
+	icon.image = load_icon(path);
+	if (icon.image == NULL)
+		return icon;
+
+	icon.image_width = cairo_image_surface_get_width(icon.image);
+	icon.image_height = cairo_image_surface_get_height(icon.image);
+
+	if (icon.image_width > icon.image_height) {
+		// Width limits size
+		if (icon.image_width > max_size) {
+			icon.width = max_size;
+			icon.scale = icon.width/icon.image_width;
+			icon.height = icon.image_height*icon.scale;
+		} else {
+			icon.width = icon.image_width;
+			icon.height = icon.image_height;
+		}
+	} else {
+		// Height limits size
+		if (icon.image_height > max_size) {
+			icon.height = max_size;
+			icon.scale = icon.height/icon.image_height;
+			icon.width = icon.image_width*icon.scale;
+		} else {
+			icon.width = icon.image_width;
+			icon.height = icon.image_height;
+		}
+	}
+
+	//printf("%f %f %f %f\n", icon.width, icon.height, icon.image_width, icon.image_height);
+
+	return icon;
+}

--- a/icon.c
+++ b/icon.c
@@ -1,10 +1,13 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <cairo/cairo.h>
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk/gdk.h>
 
 #include "icon.h"
+
+#ifdef SHOW_ICONS
+#include <gdk/gdk.h>
+#include <gdk-pixbuf/gdk-pixbuf.h>
 
 GdkPixbuf *load_image(const char *path) {
 	if (strlen(path) == 0) {
@@ -19,52 +22,59 @@ GdkPixbuf *load_image(const char *path) {
 	return pixbuf;
 }
 
-struct mako_icon create_icon(const char *path, double max_size) {
-	struct mako_icon icon;
-	icon.image = load_image(path);
-	if (icon.image == NULL) {
-		return icon;
-	}
+double fit_to_square(int width, int height, int square_size) {
+	double longest = width > height ? width : height;
+	return longest > square_size ? square_size/longest : 1.0;
+}
 
-	icon.image_width = gdk_pixbuf_get_width(icon.image);
-	icon.image_height = gdk_pixbuf_get_height(icon.image);
+void set_icon_image(struct mako_icon *icon, GdkPixbuf *image) {
+	icon->image =
+		cairo_image_surface_create(CAIRO_FORMAT_ARGB32, icon->width, icon->height);
+	cairo_t *cairo = cairo_create(icon->image);
+	cairo_scale(cairo, icon->scale, icon->scale);
+	gdk_cairo_set_source_pixbuf(cairo, image, 0, 0);
+	cairo_paint(cairo);
+	cairo_destroy(cairo);
+}
 
-	if (icon.image_width > icon.image_height) {
-		// Width limits size
-		if (icon.image_width > max_size) {
-			icon.width = max_size;
-			icon.scale = icon.width/icon.image_width;
-			icon.height = icon.image_height*icon.scale;
-		} else {
-			icon.width = icon.image_width;
-			icon.height = icon.image_height;
-		}
-	} else {
-		// Height limits size
-		if (icon.image_height > max_size) {
-			icon.height = max_size;
-			icon.scale = icon.height/icon.image_height;
-			icon.width = icon.image_width*icon.scale;
-		} else {
-			icon.width = icon.image_width;
-			icon.height = icon.image_height;
-		}
+struct mako_icon *create_icon(const char *path, double max_size) {
+	GdkPixbuf *image = load_image(path);
+	if (image == NULL) {
+		return NULL;
 	}
+	int image_width = gdk_pixbuf_get_width(image);
+	int image_height = gdk_pixbuf_get_height(image);
+
+	struct mako_icon *icon = calloc(1, sizeof(struct mako_icon));
+	icon->scale = fit_to_square(image_width, image_height, max_size);
+	icon->width = image_width * icon->scale;
+	icon->height = image_height * icon->scale;
+	set_icon_image(icon, image);
+
+	g_object_unref(image);
 
 	return icon;
 }
+#else
+struct mako_icon *create_icon(const char *path, double max_size) {
+	return NULL;
+}
+#endif
 
-void draw_icon(cairo_t *cairo, struct mako_icon icon,
+void draw_icon(cairo_t *cairo, struct mako_icon *icon,
 		double xpos, double ypos, double scale) {
 	cairo_save(cairo);
-	cairo_scale(cairo, icon.scale * scale, icon.scale * scale);
-	gdk_cairo_set_source_pixbuf(cairo, icon.image, xpos / icon.scale, ypos / icon.scale);
+	cairo_scale(cairo, scale, scale);
+	cairo_set_source_surface(cairo, icon->image, xpos, ypos);
 	cairo_paint(cairo);
 	cairo_restore(cairo);
 }
 
-void destroy_icon(struct mako_icon icon) {
-	if (icon.image != NULL) {
-		g_object_unref(icon.image);
+void destroy_icon(struct mako_icon *icon) {
+	if (icon != NULL) {
+		if (icon->image != NULL) {
+			cairo_surface_destroy(icon->image);
+		}
+		free(icon);
 	}
 }

--- a/icon.c
+++ b/icon.c
@@ -5,11 +5,11 @@
 
 #include "icon.h"
 
-#ifdef SHOW_ICONS
+#ifdef HAVE_ICONS
 #include <gdk/gdk.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 
-GdkPixbuf *load_image(const char *path) {
+static GdkPixbuf *load_image(const char *path) {
 	if (strlen(path) == 0) {
 		return NULL;
 	}
@@ -17,12 +17,13 @@ GdkPixbuf *load_image(const char *path) {
 	GdkPixbuf *pixbuf = gdk_pixbuf_new_from_file(path, &err);
 	if (!pixbuf) {
 		fprintf(stderr, "Failed to load icon (%s)\n", err->message);
+		g_error_free(err);
 		return NULL;
 	}
 	return pixbuf;
 }
 
-double fit_to_square(int width, int height, int square_size) {
+static double fit_to_square(int width, int height, int square_size) {
 	double longest = width > height ? width : height;
 	return longest > square_size ? square_size/longest : 1.0;
 }

--- a/icon.c
+++ b/icon.c
@@ -22,8 +22,9 @@ GdkPixbuf *load_image(const char *path) {
 struct mako_icon create_icon(const char *path, double max_size) {
 	struct mako_icon icon;
 	icon.image = load_image(path);
-	if (icon.image == NULL)
+	if (icon.image == NULL) {
 		return icon;
+	}
 
 	icon.image_width = gdk_pixbuf_get_width(icon.image);
 	icon.image_height = gdk_pixbuf_get_height(icon.image);
@@ -63,7 +64,7 @@ void draw_icon(cairo_t *cairo, struct mako_icon icon,
 }
 
 void destroy_icon(struct mako_icon icon) {
-	if (icon.image !=  NULL) {
+	if (icon.image != NULL) {
 		g_object_unref(icon.image);
 	}
 }

--- a/include/config.h
+++ b/include/config.h
@@ -24,8 +24,8 @@ enum mako_sort_criteria {
 // structs are also mirrored.
 struct mako_style_spec {
 	bool width, height, margin, padding, border_size, font, markup, format,
-		 actions, default_timeout, ignore_timeout, group_criteria_spec,
-		 invisible;
+		 actions, default_timeout, ignore_timeout, max_icon_size,
+		 group_criteria_spec, invisible;
 
 	struct {
 		bool background, text, border, progress;
@@ -41,6 +41,7 @@ struct mako_style {
 	struct mako_directional margin;
 	struct mako_directional padding;
 	int32_t border_size;
+	int32_t max_icon_size;
 
 	char *font;
 	bool markup;

--- a/include/config.h
+++ b/include/config.h
@@ -24,7 +24,7 @@ enum mako_sort_criteria {
 // structs are also mirrored.
 struct mako_style_spec {
 	bool width, height, margin, padding, border_size, font, markup, format,
-		 actions, default_timeout, ignore_timeout, max_icon_size,
+		 actions, default_timeout, ignore_timeout, show_icons, max_icon_size,
 		 group_criteria_spec, invisible;
 
 	struct {
@@ -41,6 +41,8 @@ struct mako_style {
 	struct mako_directional margin;
 	struct mako_directional padding;
 	int32_t border_size;
+
+	bool show_icons;
 	int32_t max_icon_size;
 
 	char *font;

--- a/include/config.h
+++ b/include/config.h
@@ -24,7 +24,7 @@ enum mako_sort_criteria {
 // structs are also mirrored.
 struct mako_style_spec {
 	bool width, height, margin, padding, border_size, font, markup, format,
-		 actions, default_timeout, ignore_timeout, show_icons, max_icon_size,
+		 actions, default_timeout, ignore_timeout, icons, max_icon_size,
 		 group_criteria_spec, invisible;
 
 	struct {
@@ -42,7 +42,7 @@ struct mako_style {
 	struct mako_directional padding;
 	int32_t border_size;
 
-	bool show_icons;
+	bool icons;
 	int32_t max_icon_size;
 
 	char *font;

--- a/include/icon.h
+++ b/include/icon.h
@@ -1,0 +1,17 @@
+#ifndef MAKO_ICON_H
+#define MAKO_ICON_H
+
+#include <cairo/cairo.h>
+
+struct mako_icon {
+	double width;
+	double height;
+	double image_width;
+	double image_height;
+	double scale;
+	cairo_surface_t* image;
+};
+
+struct mako_icon get_icon(const char *path, double max_size);
+
+#endif

--- a/include/icon.h
+++ b/include/icon.h
@@ -13,7 +13,7 @@ struct mako_icon {
 	GdkPixbuf* image;
 };
 
-struct mako_icon get_icon(const char *path, double max_size);
+struct mako_icon create_icon(const char *path, double max_size);
 void destroy_icon(struct mako_icon icon);
 void destroy_icon(struct mako_icon icon);
 void draw_icon(cairo_t *cairo, struct mako_icon icon,

--- a/include/icon.h
+++ b/include/icon.h
@@ -15,7 +15,6 @@ struct mako_icon {
 
 struct mako_icon create_icon(const char *path, double max_size);
 void destroy_icon(struct mako_icon icon);
-void destroy_icon(struct mako_icon icon);
 void draw_icon(cairo_t *cairo, struct mako_icon icon,
 		double xpos, double ypos, double scale);
 

--- a/include/icon.h
+++ b/include/icon.h
@@ -10,7 +10,7 @@ struct mako_icon {
 	double image_width;
 	double image_height;
 	double scale;
-	GdkPixbuf* image;
+	GdkPixbuf *image;
 };
 
 struct mako_icon create_icon(const char *path, double max_size);

--- a/include/icon.h
+++ b/include/icon.h
@@ -2,12 +2,7 @@
 #define MAKO_ICON_H
 
 #include <cairo/cairo.h>
-
-#ifdef SHOW_ICONS
 #include <gdk-pixbuf/gdk-pixbuf.h>
-#else
-typedef void GdkPixbuf;
-#endif
 
 struct mako_icon {
 	double width;

--- a/include/icon.h
+++ b/include/icon.h
@@ -3,15 +3,25 @@
 
 #include <cairo/cairo.h>
 
+#ifdef SHOW_ICONS
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#else
+typedef void GdkPixbuf;
+#endif
+
 struct mako_icon {
 	double width;
 	double height;
 	double image_width;
 	double image_height;
 	double scale;
-	cairo_surface_t* image;
+	GdkPixbuf* image;
 };
 
 struct mako_icon get_icon(const char *path, double max_size);
+void destroy_icon(struct mako_icon icon);
+void destroy_icon(struct mako_icon icon);
+void draw_icon(cairo_t *cairo, struct mako_icon icon,
+		double xpos, double ypos, double scale);
 
 #endif

--- a/include/icon.h
+++ b/include/icon.h
@@ -2,20 +2,17 @@
 #define MAKO_ICON_H
 
 #include <cairo/cairo.h>
-#include <gdk-pixbuf/gdk-pixbuf.h>
 
 struct mako_icon {
 	double width;
 	double height;
-	double image_width;
-	double image_height;
 	double scale;
-	GdkPixbuf *image;
+	cairo_surface_t *image;
 };
 
-struct mako_icon create_icon(const char *path, double max_size);
-void destroy_icon(struct mako_icon icon);
-void draw_icon(cairo_t *cairo, struct mako_icon icon,
+struct mako_icon *create_icon(const char *path, double max_size);
+void destroy_icon(struct mako_icon *icon);
+void draw_icon(cairo_t *cairo, struct mako_icon *icon,
 		double xpos, double ypos, double scale);
 
 #endif

--- a/include/notification.h
+++ b/include/notification.h
@@ -11,6 +11,7 @@
 struct mako_state;
 struct mako_timer;
 struct mako_criteria;
+struct mako_icon;
 
 struct mako_hotspot {
 	int32_t x, y;
@@ -22,6 +23,7 @@ struct mako_notification {
 	struct wl_list link; // mako_state::notifications
 
 	struct mako_style style;
+	struct mako_icon *icon;
 
 	uint32_t id;
 	int group_index;

--- a/main.c
+++ b/main.c
@@ -29,7 +29,7 @@ static const char usage[] =
 	"      --border-size <px>          Border size.\n"
 	"      --border-color <color>      Border color.\n"
 	"      --progress-color <color>    Progress indicator color.\n"
-	"      --icons <0|1>          Show icons in notifications.\n"
+	"      --icons <0|1>               Show icons in notifications.\n"
 	"      --max-icon-size <px>        Set max size of icons.\n"
 	"      --markup <0|1>              Enable/disable markup.\n"
 	"      --format <format>           Format string.\n"

--- a/main.c
+++ b/main.c
@@ -29,7 +29,7 @@ static const char usage[] =
 	"      --border-size <px>          Border size.\n"
 	"      --border-color <color>      Border color.\n"
 	"      --progress-color <color>    Progress indicator color.\n"
-	"      --show-icons <0|1>          Show icons in notifications.\n"
+	"      --icons <0|1>          Show icons in notifications.\n"
 	"      --max-icon-size <px>        Set max size of icons.\n"
 	"      --markup <0|1>              Enable/disable markup.\n"
 	"      --format <format>           Format string.\n"

--- a/main.c
+++ b/main.c
@@ -29,6 +29,8 @@ static const char usage[] =
 	"      --border-size <px>          Border size.\n"
 	"      --border-color <color>      Border color.\n"
 	"      --progress-color <color>    Progress indicator color.\n"
+	"      --show-icons <0|1>          Show icons in notifications.\n"
+	"      --max-icon-size <px>        Set max size of icons.\n"
 	"      --markup <0|1>              Enable/disable markup.\n"
 	"      --format <format>           Format string.\n"
 	"      --hidden-format <format>    Format string.\n"

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -116,6 +116,11 @@ dismissed with a click or via *makoctl*(1).
 
 	Default: over #5588AAFF
 
+*--max-icon-size* _px_
+	Set maximum icon size to _px_ pixels.
+
+	Default: 64
+
 *--markup* 0|1
 	If 1, enable Pango markup. If 0, disable Pango markup. If enabled, Pango
 	markup will be interpreted in your format specifier and in the body of

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -116,7 +116,7 @@ dismissed with a click or via *makoctl*(1).
 
 	Default: over #5588AAFF
 
-*--show-icons* 0|1
+*--icons* 0|1
 	Show icons in notifications.
 
 	Default: 1

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -116,6 +116,11 @@ dismissed with a click or via *makoctl*(1).
 
 	Default: over #5588AAFF
 
+*--show-icons* 0|1
+	Show icons in notifications.
+
+	Default: 1
+
 *--max-icon-size* _px_
 	Set maximum icon size to _px_ pixels.
 

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ endif
 
 gdk = dependency('gdk-3.0', required: get_option('icon'))
 gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('icon'))
-icon_feature = not get_option('icon').disabled() and gdk.found() and gdk_pixbuf.found()
+icon_feature = not get_option('icon').disabled()
 if icon_feature
 	add_global_arguments('-DSHOW_ICONS=1', language : 'c')
 endif

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
 	'c',
 	version: '1.2.0',
 	license: 'MIT',
-	meson_version: '>=0.43.0',
+	meson_version: '>=0.47.0',
 	default_options: [
 		'c_std=c11',
 		'warning_level=2',
@@ -21,7 +21,6 @@ cc = meson.get_compiler('c')
 cairo = dependency('cairo')
 pango = dependency('pango')
 pangocairo = dependency('pangocairo')
-gdk_pixbuf = dependency('gdk-pixbuf-2.0')
 realtime = cc.find_library('rt')
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
@@ -32,6 +31,13 @@ if logind.found()
 else
 	logind = dependency('libelogind')
 	add_project_arguments('-DHAVE_ELOGIND=1', language : 'c')
+endif
+
+gdk = dependency('gdk-3.0', required: get_option('icon'))
+gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('icon'))
+if not get_option('icon').disabled() and gdk.found() and gdk_pixbuf.found()
+	warning('ICON ENABLED')
+	add_global_arguments('-DSHOW_ICONS=1', language : 'c')
 endif
 
 subdir('protocol')
@@ -56,6 +62,7 @@ executable(
 	dependencies: [
 		cairo,
 		client_protos,
+		gdk,
 		gdk_pixbuf,
 		logind,
 		pango,

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,7 @@ cc = meson.get_compiler('c')
 cairo = dependency('cairo')
 pango = dependency('pango')
 pangocairo = dependency('pangocairo')
+gdk_pixbuf = dependency('gdk-pixbuf-2.0')
 realtime = cc.find_library('rt')
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
@@ -43,6 +44,7 @@ executable(
 		'dbus/dbus.c',
 		'dbus/mako.c',
 		'dbus/xdg.c',
+		'icon.c',
 		'main.c',
 		'notification.c',
 		'pool-buffer.c',
@@ -54,6 +56,7 @@ executable(
 	dependencies: [
 		cairo,
 		client_protos,
+		gdk_pixbuf,
 		logind,
 		pango,
 		pangocairo,

--- a/meson.build
+++ b/meson.build
@@ -35,30 +35,35 @@ endif
 
 gdk = dependency('gdk-3.0', required: get_option('icon'))
 gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('icon'))
-if not get_option('icon').disabled() and gdk.found() and gdk_pixbuf.found()
-	warning('ICON ENABLED')
+icon_feature = not get_option('icon').disabled() and gdk.found() and gdk_pixbuf.found()
+if icon_feature
 	add_global_arguments('-DSHOW_ICONS=1', language : 'c')
 endif
 
 subdir('protocol')
 
+src_files = [
+	'config.c',
+	'event-loop.c',
+	'dbus/dbus.c',
+	'dbus/mako.c',
+	'dbus/xdg.c',
+	'main.c',
+	'notification.c',
+	'pool-buffer.c',
+	'render.c',
+	'wayland.c',
+	'criteria.c',
+	'types.c',
+]
+
+if icon_feature
+	src_files += 'icon.c'
+endif
+
 executable(
 	'mako',
-	files([
-		'config.c',
-		'event-loop.c',
-		'dbus/dbus.c',
-		'dbus/mako.c',
-		'dbus/xdg.c',
-		'icon.c',
-		'main.c',
-		'notification.c',
-		'pool-buffer.c',
-		'render.c',
-		'wayland.c',
-		'criteria.c',
-		'types.c',
-	]),
+	files(src_files),
 	dependencies: [
 		cairo,
 		client_protos,

--- a/meson.build
+++ b/meson.build
@@ -33,11 +33,10 @@ else
 	add_project_arguments('-DHAVE_ELOGIND=1', language : 'c')
 endif
 
-gdk = dependency('gdk-3.0', required: get_option('icon'))
-gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('icon'))
-icon_feature = not get_option('icon').disabled()
-if icon_feature
-	add_global_arguments('-DSHOW_ICONS=1', language : 'c')
+gdk = dependency('gdk-3.0', required: get_option('icons'))
+gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('icons'))
+if gdk.found() and gdk_pixbuf.found()
+	add_global_arguments('-DHAVE_ICONS=1', language : 'c')
 endif
 
 subdir('protocol')

--- a/meson.build
+++ b/meson.build
@@ -55,11 +55,8 @@ src_files = [
 	'wayland.c',
 	'criteria.c',
 	'types.c',
+	'icon.c'
 ]
-
-if icon_feature
-	src_files += 'icon.c'
-endif
 
 executable(
 	'mako',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,1 @@
-option('icon', type: 'feature', value: 'enabled', description: 'Enable icon support')
+option('icons', type: 'feature', value: 'auto', description: 'Enable icon support')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('icon', type: 'feature', value: 'auto', description: 'Enable icon support')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,1 @@
-option('icon', type: 'feature', value: 'auto', description: 'Enable icon support')
+option('icon', type: 'feature', value: 'enabled', description: 'Enable icon support')

--- a/notification.c
+++ b/notification.c
@@ -17,6 +17,7 @@
 #include "event-loop.h"
 #include "mako.h"
 #include "notification.h"
+#include "icon.h"
 
 bool hotspot_at(struct mako_hotspot *hotspot, int32_t x, int32_t y) {
 	return x >= hotspot->x &&
@@ -53,6 +54,9 @@ void reset_notification(struct mako_notification *notif) {
 	notif->body = NULL;
 	notif->category = NULL;
 	notif->desktop_entry = NULL;
+
+	destroy_icon(notif->icon);
+	notif->icon = NULL;
 }
 
 struct mako_notification *create_notification(struct mako_state *state) {

--- a/render.c
+++ b/render.c
@@ -96,7 +96,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	double text_x = style->padding.left;
 #ifdef SHOW_ICONS
 	struct mako_icon icon;
-	if (style->show_icons) {
+	if (style->icons) {
 		icon = create_icon(icon_path, style->max_icon_size);
 		if (icon.image != NULL) {
 			text_x = icon.width + 2*style->padding.left;
@@ -149,7 +149,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 
 	int notif_height;
 #ifdef SHOW_ICONS
-	if (style->show_icons && icon.image != NULL && icon.height > text_height) {
+	if (style->icons && icon.image != NULL && icon.height > text_height) {
 		notif_height = icon.height + border_size + padding_height;
 	} else {
 		notif_height = text_height + border_size + padding_height;
@@ -205,7 +205,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 
 #ifdef SHOW_ICONS
 	// Render icon
-	if (style->show_icons && icon.image != NULL) {
+	if (style->icons && icon.image != NULL) {
 		double xpos = offset_x + style->border_size +
 			(text_x - icon.width) / 2;
 		double ypos = offset_y + style->border_size +

--- a/render.c
+++ b/render.c
@@ -91,7 +91,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	}
 
 	double text_x = style->padding.left;
-	if (style->icons && icon != NULL) {
+	if (icon != NULL) {
 		text_x = icon->width + 2*style->padding.left;
 	}
 
@@ -139,7 +139,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	int text_height = buffer_text_height / scale;
 
 	int notif_height = text_height + border_size + padding_height;
-	if (style->icons && icon != NULL && icon->height > text_height) {
+	if (icon != NULL && icon->height > text_height) {
 		notif_height = icon->height + border_size + padding_height;
 	}
 
@@ -188,7 +188,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	cairo_fill(cairo);
 	cairo_restore(cairo);
 
-	if (style->icons && icon != NULL) {
+	if (icon != NULL) {
 		// Render icon
 		double xpos = offset_x + style->border_size +
 			(text_x - icon->width) / 2;

--- a/render.c
+++ b/render.c
@@ -97,7 +97,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 #ifdef SHOW_ICONS
 	struct mako_icon icon;
 	if (style->show_icons) {
-		icon = get_icon(icon_path, style->max_icon_size);
+		icon = create_icon(icon_path, style->max_icon_size);
 		if (icon.image != NULL) {
 			text_x = icon.width + 2*style->padding.left;
 		}

--- a/render.c
+++ b/render.c
@@ -201,12 +201,8 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 			(text_x - icon.width) / 2;
 		double ypos = offset_y + style->border_size +
 			(notif_height - icon.height - border_size) / 2;
-		cairo_save(cairo);
-		cairo_scale(cairo, icon.scale * scale, icon.scale * scale);
-		cairo_set_source_surface(cairo, icon.image, xpos / icon.scale, ypos / icon.scale);
-		cairo_paint(cairo);
-		cairo_restore(cairo);
-		cairo_surface_destroy(icon.image);
+		draw_icon(cairo, icon, xpos, ypos, scale);
+		destroy_icon(icon);
 	}
 
 	// Render text

--- a/render.c
+++ b/render.c
@@ -4,7 +4,9 @@
 #include <pango/pangocairo.h>
 #include <assert.h>
 
+#ifdef SHOW_ICONS
 #include "icon.h"
+#endif
 
 #include "config.h"
 #include "criteria.h"
@@ -91,14 +93,17 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 		offset_x = style->margin.left;
 	}
 
-	struct mako_icon icon = get_icon(icon_path, style->max_icon_size);
-
 	double text_x;
+#ifdef SHOW_ICONS
+	struct mako_icon icon = get_icon(icon_path, style->max_icon_size);
 	if (icon.image == NULL) {
 		text_x = style->padding.left;
 	} else {
 		text_x = icon.width + 2*style->padding.left;
 	}
+#else
+	text_x = style->padding.left;
+#endif
 
 	set_font_options(cairo, state);
 
@@ -144,11 +149,15 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	int text_height = buffer_text_height / scale;
 
 	int notif_height;
+#ifdef SHOW_ICONS
 	if (icon.image != NULL && icon.height > text_height) {
 		notif_height = icon.height + border_size + padding_height;
 	} else {
 		notif_height = text_height + border_size + padding_height;
 	}
+#else
+	notif_height = text_height + border_size + padding_height;
+#endif
 
 	// Render border
 	set_source_u32(cairo, style->colors.border);
@@ -195,6 +204,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	cairo_fill(cairo);
 	cairo_restore(cairo);
 
+#ifdef SHOW_ICONS
 	// Render icon
 	if (icon.image != NULL) {
 		double xpos = offset_x + style->border_size +
@@ -204,6 +214,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 		draw_icon(cairo, icon, xpos, ypos, scale);
 		destroy_icon(icon);
 	}
+#endif
 
 	// Render text
 	set_source_u32(cairo, style->colors.text);

--- a/render.c
+++ b/render.c
@@ -93,16 +93,15 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 		offset_x = style->margin.left;
 	}
 
-	double text_x;
+	double text_x = style->padding.left;
 #ifdef SHOW_ICONS
-	struct mako_icon icon = get_icon(icon_path, style->max_icon_size);
-	if (icon.image == NULL) {
-		text_x = style->padding.left;
-	} else {
-		text_x = icon.width + 2*style->padding.left;
+	struct mako_icon icon;
+	if (style->show_icons) {
+		icon = get_icon(icon_path, style->max_icon_size);
+		if (icon.image != NULL) {
+			text_x = icon.width + 2*style->padding.left;
+		}
 	}
-#else
-	text_x = style->padding.left;
 #endif
 
 	set_font_options(cairo, state);
@@ -150,7 +149,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 
 	int notif_height;
 #ifdef SHOW_ICONS
-	if (icon.image != NULL && icon.height > text_height) {
+	if (style->show_icons && icon.image != NULL && icon.height > text_height) {
 		notif_height = icon.height + border_size + padding_height;
 	} else {
 		notif_height = text_height + border_size + padding_height;
@@ -206,7 +205,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 
 #ifdef SHOW_ICONS
 	// Render icon
-	if (icon.image != NULL) {
+	if (style->show_icons && icon.image != NULL) {
 		double xpos = offset_x + style->border_size +
 			(text_x - icon.width) / 2;
 		double ypos = offset_y + style->border_size +

--- a/render.c
+++ b/render.c
@@ -321,7 +321,7 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 		format_text(style.format, text, format_hidden_text, &data);
 
 		int hidden_height = render_notification(
-			cairo, state, &style, text, notif->icon, total_height, scale, NULL, 0);
+			cairo, state, &style, text, NULL, total_height, scale, NULL, 0);
 		free(text);
 		finish_style(&style);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15268706/52900759-55a56b00-31fa-11e9-8544-4f521897b377.png)

Adds preliminary support for icons, assuming they are given as an image path. Support for the other options in https://developer.gnome.org/notification-spec/#icons-and-images could be worked on later.

Image loading code is mostly borrowed from swaybg and adds a dependency on gdk-pixbuf. This could be made an optional dependency, I removed that aspect for the sake of simplicity when writing the code.

Some changes to the present rendering code had to be done
* If no icon is present (or if it failed to load) then the behavior would be unchanged
* If an icon is present a spacing of padding.left is given on both sides (padding, icon, padding, text)
* The icon and text are both vertically centered, so it looks nice if text is taller than the icon and vice versa

Additional icon logic
* The icon is fitted (maintaining aspect ratio) inside a square of `max_icon_size`

Adding support for the other icon formats in the spec wouldn't change the rendering logic, so hopefully this can be merged independently. Some code would have to change to pass relevant parameters, but that's about it.

Partially resolves https://github.com/emersion/mako/issues/37.