### PR TITLE
Fix border misalignment due to double->int conversion

### DIFF
--- a/render.c
+++ b/render.c
@@ -30,11 +30,11 @@ static void set_layout_size(PangoLayout *layout, int width, int height,
 	pango_layout_set_height(layout, height * scale * PANGO_SCALE);
 }
 
-static void move_to(cairo_t *cairo, int x, int y, int scale) {
+static void move_to(cairo_t *cairo, double x, double y, int scale) {
 	cairo_move_to(cairo, x * scale, y * scale);
 }
 
-static void set_rectangle(cairo_t *cairo, int x, int y, int width, int height,
+static void set_rectangle(cairo_t *cairo, double x, double y, double width, double height,
 		int scale) {
 	cairo_rectangle(cairo, x * scale, y * scale, width * scale, height * scale);
 }


### PR DESCRIPTION
This part of the border rendering

    set_rectangle(cairo,
        offset_x + style->border_size / 2.0,
        offset_y + style->border_size / 2.0,
        notif_width - style->border_size,
        notif_height - style->border_size,
        scale);

Can pass non-integer values for x and y positions (half pixels in the case of odd width border). However the signature of `set_rectangle` is all ints. This causes the coordinate to be rounded towards zero and the whole border is shifted a half pixel to the right/up.

This PR changes the signature of the cairo wrappers in `render.c` to take doubles for relevant arguments. It's possible that more variables should be doubles in the overall code, but this correction resolves the rendering error.