### PR TITLE
Add true 'center' anchor option, and re-organize order of options

### DIFF
--- a/config.c
+++ b/config.c
@@ -386,6 +386,11 @@ static bool apply_config_option(struct mako_config *config, const char *name,
 		if (strcmp(value, "top-right") == 0) {
 			config->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
 				ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
+		} else if (strcmp(value, "top-center") == 0) {
+			config->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
+		} else if (strcmp(value, "top-left") == 0) {
+			config->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
+				ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
 		} else if (strcmp(value, "bottom-right") == 0) {
 			config->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
 				ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
@@ -394,11 +399,8 @@ static bool apply_config_option(struct mako_config *config, const char *name,
 		} else if (strcmp(value, "bottom-left") == 0) {
 			config->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
 				ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
-		} else if (strcmp(value, "top-left") == 0) {
-			config->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
-				ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
-		} else if (strcmp(value, "top-center") == 0) {
-			config->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
+		} else if (strcmp(value, "center") == 0) {
+			config->anchor = 0;
 		} else {
 			return false;
 		}

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -52,8 +52,8 @@ dismissed with a click or via *makoctl*(1).
 
 *--anchor* _position_
 	Show notifications at the specified position on the output. Supported values
-	are _top-right_, _bottom-right_, _bottom-center_, _bottom-left_, _top-left_
-	and _top-center_.
+	are _top-right_, _top-center_, _top-left_, _bottom-right_, _bottom-center_,
+	_bottom-left_, and _center_.
 
 	Default: top-right
 


### PR DESCRIPTION
Inspired by https://github.com/emersion/mako/pull/87, and the fact that I use a 39" 4k TV as my monitor, I've added a true 'center' option to the anchor positions.

I also noticed that the order of options wasn't grouped as I thought it should be, so I fixed that as well. Now it goes Right, Center, Left, for both Top and Bottom. Happy to back out that change though if you feel it should be separate. ~I plan on making a PR to change the check to a switch statement next.~ Strike that, I didn't know C couldn't switch compare strings.