### PR TITLE
Add support for loading images by icon-name

### DIFF
--- a/main.c
+++ b/main.c
@@ -11,6 +11,10 @@
 #include "render.h"
 #include "wayland.h"
 
+#ifdef HAVE_ICONS
+#include <gtk/gtk.h>
+#endif
+
 static const char usage[] =
 	"Usage: mako [options...]\n"
 	"\n"
@@ -76,6 +80,10 @@ int main(int argc, char *argv[]) {
 
 	state.argc = argc;
 	state.argv = argv;
+
+#ifdef HAVE_ICONS
+	gtk_init(&argc, &argv);
+#endif
 
 	// This is a bit wasteful, but easier than special-casing the reload.
 	init_default_config(&state.config);

--- a/meson.build
+++ b/meson.build
@@ -33,9 +33,10 @@ else
 	add_project_arguments('-DHAVE_ELOGIND=1', language : 'c')
 endif
 
+gtk = dependency('gtk+-3.0', required: get_option('icons'))
 gdk = dependency('gdk-3.0', required: get_option('icons'))
 gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('icons'))
-if gdk.found() and gdk_pixbuf.found()
+if gdk.found() and gdk_pixbuf.found() and gtk.found()
 	add_global_arguments('-DHAVE_ICONS=1', language : 'c')
 endif
 
@@ -64,6 +65,7 @@ executable(
 		cairo,
 		client_protos,
 		gdk,
+		gtk,
 		gdk_pixbuf,
 		logind,
 		pango,


### PR DESCRIPTION
See issue #118 . This adds a dependency to gtk+-3.0, since the icon features are unfortunately not available in gdk. The code tries to load the argument as file/path first and otherwise falls back to icon-name based lookup otherwise.