### PR TITLE
Print usage message when not enough or too many argument are given on…

### DIFF
--- a/makoctl
+++ b/makoctl
@@ -17,6 +17,11 @@ call() {
 		fr.emersion.Mako "$@"
 }
 
+if [ $# -eq 0 ] || [ $# -gt 2 ]; then
+   usage
+   exit 1
+fi
+
 case "$1" in
 "dismiss")
 	case "$2" in


### PR DESCRIPTION
Not a killer feature but could be nice to remove the following case:

```
$ /usr/bin/makoctl
makoctl: unrecognized command ''
```

The proposed patch offer to check how many argument are given from the CLI and directly print an error message with the standard usage function.