### PR TITLE
Update README.md with dbus dependency and elogind tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A lightweight notification daemon for Wayland. Works on Sway.
 If you're using Sway you can start mako on launch by putting `exec mako` in
 your configuration file.
 
+If you are using elogind, you might need to manually start a dbus user session:
+`dbus-daemon --session --address=unix:path=$XDG_RUNTIME_DIR/bus`
+
 ## Building
 
 Install dependencies:
@@ -20,6 +23,7 @@ Install dependencies:
 * pango
 * cairo
 * systemd or elogind (for the sd-bus library)
+* dbus (with user-session support)
 
 Then run:
 


### PR DESCRIPTION
I've added two things to the readme that would have saved me a lot of time when I tried to get mako up and running on my system.