### PR TITLE
Add a missing command line border-radius option

### DIFF
--- a/config.c
+++ b/config.c
@@ -630,6 +630,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"padding", required_argument, 0, 0},
 		{"border-size", required_argument, 0, 0},
 		{"border-color", required_argument, 0, 0},
+		{"border-radius", required_argument, 0, 0},
 		{"progress-color", required_argument, 0, 0},
 		{"icons", required_argument, 0, 0},
 		{"max-icon-size", required_argument, 0, 0},


### PR DESCRIPTION
Hi,

I just compiled the latest master source and `--border-radius` option does not work.
I launch mako with these command line options below and got an error:
```
mako --border-radius 5
mako: unrecognized option '--border-radius'
Failed to parse config
```

In this PR I just added a missing command line `border-radius` option.