### PR TITLE
icon: add support for icon size and scale in second level subdir name

### DIFF
--- a/icon.c
+++ b/icon.c
@@ -112,7 +112,16 @@ static char *resolve_icon(struct mako_notification *notif) {
 			errno = 0;
 			int32_t icon_size = strtol(relative_path, NULL, 10);
 			if (errno || icon_size == 0) {
-				continue;
+				// Try second level subdirectory if failed.
+				errno = 0;
+				while (relative_path[0] != '/') {
+					++relative_path;
+				}
+				++relative_path;
+				icon_size = strtol(relative_path, NULL, 10);
+				if (errno || icon_size == 0) {
+					continue;
+				}
 			}
 
 			int32_t icon_scale = 1;


### PR DESCRIPTION
Some icon themes (like Arc, breeze ...) have their icon size and scale attribute in second level subdir name (paths like actions/16/add-files-to-archive.png). This pull request add support to this kind of naming.