### PR TITLE
Add image-data hint support

### DIFF
--- a/include/icon.h
+++ b/include/icon.h
@@ -11,6 +11,16 @@ struct mako_icon {
 	cairo_surface_t *image;
 };
 
+struct mako_image_data {
+	int32_t width;
+	int32_t height;
+	int32_t rowstride;
+	uint32_t has_alpha;
+	int32_t bits_per_sample;
+	int32_t channels;
+	uint8_t *data;
+};
+
 struct mako_icon *create_icon(struct mako_notification *notif);
 void destroy_icon(struct mako_icon *icon);
 void draw_icon(cairo_t *cairo, struct mako_icon *icon,

--- a/include/notification.h
+++ b/include/notification.h
@@ -40,6 +40,7 @@ struct mako_notification {
 	char *category;
 	char *desktop_entry;
 	int32_t progress;
+	struct mako_image_data *image_data;
 
 	struct mako_hotspot hotspot;
 	struct mako_timer *timer;

--- a/notification.c
+++ b/notification.c
@@ -48,6 +48,10 @@ void reset_notification(struct mako_notification *notif) {
 	free(notif->body);
 	free(notif->category);
 	free(notif->desktop_entry);
+	if (notif->image_data != NULL) {
+		free(notif->image_data->data);
+		free(notif->image_data);
+	}
 
 	notif->app_name = NULL;
 	notif->app_icon = NULL;
@@ -55,6 +59,7 @@ void reset_notification(struct mako_notification *notif) {
 	notif->body = NULL;
 	notif->category = NULL;
 	notif->desktop_entry = NULL;
+	notif->image_data = NULL;
 
 	destroy_icon(notif->icon);
 	notif->icon = NULL;


### PR DESCRIPTION
Add image-data hint support, which is preferred when both image-data and app_icon exist.

Tested on Firefox (which uses libnotify).