### PR TITLE
Add icon_data hint support

### DIFF
--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -217,7 +217,7 @@ static int handle_notify(sd_bus_message *msg, void *data,
 				return ret;
 			}
 			notif->progress = progress;
-		} else if (strcmp(hint, "image-data") == 0) {
+		} else if (strcmp(hint, "image-data") == 0 || strcmp(hint, "icon_data") == 0) {
 			ret = sd_bus_message_enter_container(msg, 'v', "(iiibiiay)");
 			if (ret < 0) {
 				return ret;


### PR DESCRIPTION
Building on #147, this adds support for the deprecated (though still in use) `icon_data` hint, by simply adding another `strcmp()` call to the condition that checks for `image-data` so that either will be used.

My motivation for adding this is that the Linux Spotify client is still using `icon_data` hints in its notifications.