### PR TITLE
Fix memory leak if there are multiple icon data

### DIFF
--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -274,6 +274,10 @@ static int handle_notify(sd_bus_message *msg, void *data,
 			}
 
 			image_data->data = data;
+			if (notif->image_data != NULL) {
+				free(notif->image_data->data);
+				free(notif->image_data);
+			}
 			notif->image_data = image_data;
 
 			ret = sd_bus_message_exit_container(msg);


### PR DESCRIPTION
Without this patch, memory leak can happen if both image-data and icon_data are present, or if there are hint entries with duplicate key that is either image-data or icon_data.