### PR TITLE
makoctl: unbreak 'dismiss' and 'invoke' called without argument

### DIFF
--- a/makoctl
+++ b/makoctl
@@ -23,7 +23,8 @@ fi
 
 case "$1" in
 "dismiss")
-	case "$2" in
+	[ $# -lt 2 ] && action="" || action="$2"
+	case "$action" in
 	"-a"|"--all")
 		call DismissAllNotifications
 		;;
@@ -37,7 +38,7 @@ case "$1" in
 	esac
 	;;
 "invoke")
-	action="$2"
+	[ $# -lt 2 ] && action="" || action="$2"
 	if [ -z "$action" ] ; then
 		action="default"
 	fi


### PR DESCRIPTION
When 'dismiss' and 'invoke' is called without arguments, `$2` is an
unbound variable, resulting in the following error message (caused by
makoctl being invoked with `-u`, since https://github.com/emersion/mako/commit/8bd11f25c9285a79cd00a68da48fcf68b8d1815c):
```sh
/usr/bin/makoctl: line 26: $2: unbound variable
```
This fixes it by using an intermediate variable, `action`, and
assigning the empty string to it when 'dismiss' or 'invoke' is called
without arguments.

Seen with
```sh
% sh --version
GNU bash, version 5.0.3(1)-release (x86_64-pc-linux-gnu)
```
on arch.

(or we could revert `-u` :man_shrugging: )