### PR TITLE
Add exact-string matching to criteria

### DIFF
--- a/criteria.c
+++ b/criteria.c
@@ -262,8 +262,13 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token) {
 			}
 			criteria->spec.group_index = true;
 			return true;
+		} else if (strcmp(key, "summary") == 0) {
+			// TODO: convert to regex, currently only exact matching
+			criteria->summary = strdup(value);
+			criteria->spec.summary = true;
+			return true;
 		} else {
-			// TODO: summary + body, once we support regex and they're useful.
+			// TODO: body, once we support regex and they're useful.
 			// Anything left must be one of the boolean fields, defined using
 			// standard syntax. Continue on.
 		}

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -228,6 +228,8 @@ The following fields are available in critiera:
 
 - _app-name_ (string)
 - _app-icon_ (string)
+- _summary_ (string)
+	- An exact match on the summary of the notification.
 - _urgency_ (one of "low", "normal", "high")
 - _category_ (string)
 - _desktop-entry_ (string)


### PR DESCRIPTION
Regarding my comment on https://github.com/emersion/mako/issues/152#issuecomment-490964953, this implements exact string matching on the summary of a notification, for use with known notification titles, i.e. from messaging apps.