### PR TITLE
Add a D-Bus service file for mako

### DIFF
--- a/fr.emersion.mako.service.in
+++ b/fr.emersion.mako.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.freedesktop.Notifications
+Exec=@bindir@/mako

--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,16 @@ install_data(
 	install_mode: 'rwxr-xr-x',
 )
 
+conf_data = configuration_data()
+conf_data.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
+
+configure_file(
+	configuration: conf_data,
+	input: 'fr.emersion.mako.service.in',
+	output: '@BASENAME@',
+	install_dir: datadir + '/dbus-1/services',
+)
+
 scdoc = find_program('scdoc', required: get_option('man-pages'))
 
 if scdoc.found()


### PR DESCRIPTION
This patch adds a D-Bus service file for mako.

I have never written any meson.build file before.  Suggestions are welcome.

This patch also solves an annoying issue for [Guix System](https://www.gnu.org/software/guix/).  Guix has no systemd init system and $DBUS_SESSION_BUS_ADDRESS is not set in user sessions.  
we had to start mako with `dbus-launch --autolaunch=$(dbus-uuidgen --get) mako`.  After applying this patch, mako can be automatically started by the D-Bus daemon. That complex command is not needed anymore.  I will update the package in Guix when this patch is merged.