### PR TITLE
Allow listing and invoking actions with makoctl

### DIFF
--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -46,19 +46,14 @@ static int handle_invoke_action(sd_bus_message *msg, void *data,
 	struct mako_state *state = data;
 
 	uint32_t id = 0;
-	int ret = sd_bus_message_read(msg, "u", &id);
+	const char *action_key;
+	int ret = sd_bus_message_read(msg, "us", &id, &action_key);
 	if (ret < 0) {
 		return ret;
 	}
 
 	if (id == 0) {
 		id = state->last_id;
-	}
-
-	const char *action_key;
-	ret = sd_bus_message_read(msg, "s", &action_key);
-	if (ret < 0) {
-		return ret;
 	}
 
 	if (wl_list_empty(&state->notifications)) {

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -140,24 +140,24 @@ static int handle_list_notifications(sd_bus_message *msg, void *data,
 			return ret;
 		}
 
-		// Actions are an array of strings.
-		ret = sd_bus_message_open_container(reply, 'v', "as");
+		ret = sd_bus_message_open_container(reply, 'v', "a{ss}");
 		if (ret < 0) {
 			return ret;
 		}
 
-		ret = sd_bus_message_open_container(reply, 'a', "s");
+		ret = sd_bus_message_open_container(reply, 'a', "{ss}");
 		if (ret < 0) {
 			return ret;
 		}
 
 		struct mako_action *action;
 		wl_list_for_each(action, &notif->actions, link) {
-			ret = sd_bus_message_append(reply, "s", action->key);
+			ret = sd_bus_message_append(reply, "{ss}", action->key, action->title);
 			if (ret < 0) {
 				return ret;
 			}
 		}
+
 		ret = sd_bus_message_close_container(reply);
 		if (ret < 0) {
 			return ret;

--- a/makoctl
+++ b/makoctl
@@ -4,13 +4,13 @@ usage() {
 	echo "Usage: makoctl <command> [options...]"
 	echo ""
 	echo "Commands:"
-	echo "  dismiss [-a|--all]    Dismiss the last or all notifications"
-	echo "  invoke [action] [id]  Invoke an action on the notification"
-	echo "                        with the given id, or the last"
-	echo "                        notification if none is given"
-	echo "  list                  List notifications"
-	echo "  reload                Reload the configuration file"
-	echo "  help                  Show this help"
+	echo "  dismiss [-a|--all]       Dismiss the last or all notifications"
+	echo "  invoke [-n id] [action]  Invoke an action on the notification"
+	echo "                           with the given id, or the last"
+	echo "                           notification if none is given"
+	echo "  list                     List notifications"
+	echo "  reload                   Reload the configuration file"
+	echo "  help                     Show this help"
 }
 
 call() {
@@ -18,7 +18,7 @@ call() {
 		fr.emersion.Mako "$@"
 }
 
-if [ $# -eq 0 ] || [ $# -gt 3 ]; then
+if [ $# -eq 0 ] || [ $# -gt 5 ]; then
    usage
    exit 1
 fi
@@ -40,8 +40,17 @@ case "$1" in
 	esac
 	;;
 "invoke")
-	[ $# -lt 2 ] && action="default" || action="$2"
-	[ $# -lt 3 ] && id="0" || id="$3"
+	id=0
+	if [ $# -gt 1 ] && [ $2 == "-n" ]; then
+		id="$3"
+		shift 2
+	fi
+
+	action="default"
+	if [ $# -gt 1 ]; then
+		action="$2"
+	fi
+
 	call InvokeAction "us" "$id" "$action"
 	;;
 "list")

--- a/makoctl
+++ b/makoctl
@@ -4,11 +4,13 @@ usage() {
 	echo "Usage: makoctl <command> [options...]"
 	echo ""
 	echo "Commands:"
-	echo "  dismiss [-a|--all] Dismiss the last or all notifications"
-	echo "  invoke [action]    Invoke an action on the last notification"
-	echo "  list               List notifications"
-	echo "  reload             Reload the configuration file"
-	echo "  help               Show this help"
+	echo "  dismiss [-a|--all]    Dismiss the last or all notifications"
+	echo "  invoke [action] [id]  Invoke an action on the notification"
+	echo "                        with the given id, or the last"
+	echo "                        notification if none is given"
+	echo "  list                  List notifications"
+	echo "  reload                Reload the configuration file"
+	echo "  help                  Show this help"
 }
 
 call() {
@@ -16,7 +18,7 @@ call() {
 		fr.emersion.Mako "$@"
 }
 
-if [ $# -eq 0 ] || [ $# -gt 2 ]; then
+if [ $# -eq 0 ] || [ $# -gt 3 ]; then
    usage
    exit 1
 fi
@@ -38,11 +40,9 @@ case "$1" in
 	esac
 	;;
 "invoke")
-	[ $# -lt 2 ] && action="" || action="$2"
-	if [ -z "$action" ] ; then
-		action="default"
-	fi
-	call InvokeAction "s" "$action"
+	[ $# -lt 2 ] && action="default" || action="$2"
+	[ $# -lt 3 ] && id="0" || id="$3"
+	call InvokeAction "us" "$id" "$action"
 	;;
 "list")
 	call ListNotifications


### PR DESCRIPTION
This is like 2% of the way toward #4. I'm posting this mostly to see if this method of interacting with actions is even useful, or if it's too difficult. With this change, you can invoke actions like:
```
makoctl invoke default 33
```
where `default` is the action's key and `33` is the internal id. I chose to expose the id rather than just using the visible index to avoid race conditions in external scripts. You still have to invoke the action before the notification vanishes, you can't accidentally invoke it on the wrong one this way.

Here's some example `jq` for listing the json of visible notifications, which contains the id and action list necessary to invoke this:
```
makoctl list | jq -r '.data[][] | .[] |= .data'
```

I may have done the sd-bus stuff in the hardest possible way, I'm not super familar with the library and there are few manpages.