### PR TITLE
notification.c: use correct format arguments

### DIFF
--- a/notification.c
+++ b/notification.c
@@ -188,9 +188,9 @@ char *format_hidden_text(char variable, bool *markup, void *data) {
 	struct mako_hidden_format_data *format_data = data;
 	switch (variable) {
 	case 'h':
-		return mako_asprintf("%d", format_data->hidden);
+		return mako_asprintf("%zu", format_data->hidden);
 	case 't':
-		return mako_asprintf("%d", format_data->count);
+		return mako_asprintf("%zu", format_data->count);
 	}
 	return NULL;
 }


### PR DESCRIPTION
Minor fix to use `%zu` instead of `%d` to format the `size_t` values.

I don't think this will ever actually break, except *maybe* on insane systems where int is small, if somehow enough notifications get sent to overflow things.... but it feels right to fix it anyway.

Tried to actually get this to break on my machine and discovered that `seq 1 1<<33` breaks my shell :P.

Obligatory corporate stuff (LGTM *is* cool, though, I promise :P):
This was found using LGTM.com, there are some other findings [here](https://lgtm.com/projects/g/emersion/mako/alerts/?mode=list) and you can [enable automated PR analysis](https://lgtm.com/projects/g/irtimmer/moonlight-embedded/ci/) to guard against new issues being introduced.

Full disclosure: I work for Semmle, the company behind LGTM.com
