### PR TITLE
Initial touch support

### DIFF
--- a/config.c
+++ b/config.c
@@ -58,9 +58,10 @@ void init_default_config(struct mako_config *config) {
 	config->sort_criteria = MAKO_SORT_CRITERIA_TIME;
 	config->sort_asc = 0;
 
-	config->button_bindings.left = MAKO_BUTTON_BINDING_INVOKE_DEFAULT_ACTION;
-	config->button_bindings.right = MAKO_BUTTON_BINDING_DISMISS;
-	config->button_bindings.middle = MAKO_BUTTON_BINDING_NONE;
+	config->button_bindings.left = MAKO_BINDING_INVOKE_DEFAULT_ACTION;
+	config->button_bindings.right = MAKO_BINDING_DISMISS;
+	config->button_bindings.middle = MAKO_BINDING_NONE;
+	config->touch = MAKO_BINDING_DISMISS;
 
 	config->anchor =
 		ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;

--- a/include/config.h
+++ b/include/config.h
@@ -7,11 +7,11 @@
 #include "types.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
-enum mako_button_binding {
-	MAKO_BUTTON_BINDING_NONE,
-	MAKO_BUTTON_BINDING_DISMISS,
-	MAKO_BUTTON_BINDING_DISMISS_ALL,
-	MAKO_BUTTON_BINDING_INVOKE_DEFAULT_ACTION,
+enum mako_binding {
+	MAKO_BINDING_NONE,
+	MAKO_BINDING_DISMISS,
+	MAKO_BINDING_DISMISS_ALL,
+	MAKO_BINDING_INVOKE_DEFAULT_ACTION,
 };
 
 enum mako_sort_criteria {
@@ -81,8 +81,10 @@ struct mako_config {
 	struct mako_style superstyle;
 
 	struct {
-		enum mako_button_binding left, right, middle;
+		enum mako_binding left, right, middle;
 	} button_bindings;
+
+	enum mako_binding touch;
 };
 
 void init_default_config(struct mako_config *config);

--- a/include/notification.h
+++ b/include/notification.h
@@ -88,6 +88,9 @@ size_t format_notification(struct mako_notification *notif, const char *format,
 	char *buf);
 void notification_handle_button(struct mako_notification *notif, uint32_t button,
 	enum wl_pointer_button_state state);
+void notification_handle_touch(struct mako_notification *notif);
+void notification_execute_binding(struct mako_notification *notif,
+	enum mako_binding binding);
 void insert_notification(struct mako_state *state, struct mako_notification *notif);
 int group_notifications(struct mako_state *state, struct mako_criteria *criteria);
 

--- a/include/wayland.h
+++ b/include/wayland.h
@@ -27,6 +27,11 @@ struct mako_seat {
 		struct wl_pointer *wl_pointer;
 		int32_t x, y;
 	} pointer;
+
+	struct {
+		struct wl_touch *wl_touch;
+		int32_t x, y;
+	} touch;
 };
 
 bool init_wayland(struct mako_state *state);


### PR DESCRIPTION
Listen for touch down, motion and up events.

Nind 'press' event to 'up' action. bind 'down' and 'motion'
to x and y tracking.

Implement the button press dispatching as a simple
'mocked' button press using BTN_TOUCH so it fits in
with the existing button press event structure.

Fixes #99