### PR TITLE
Support image-path and more deprecated hints

### DIFF
--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -217,7 +217,22 @@ static int handle_notify(sd_bus_message *msg, void *data,
 				return ret;
 			}
 			notif->progress = progress;
-		} else if (strcmp(hint, "image-data") == 0 || strcmp(hint, "icon_data") == 0) {
+		} else if (strcmp(hint, "image-path") == 0 ||
+				strcmp(hint, "image_path") == 0) {  // Deprecated.
+			const char *image_path = NULL;
+			ret = sd_bus_message_read(msg, "v", "s", &image_path);
+			if (ret < 0) {
+				return ret;
+			}
+			// image-path is higher priority than app_icon, so just overwrite
+			// it. We're guaranteed to be doing this after reading the "real"
+			// app_icon. It's also lower priority than image-data, and that
+			// will win over app_icon if provided.
+			free(notif->app_icon);
+			notif->app_icon = strdup(image_path);
+		} else if (strcmp(hint, "image-data") == 0 ||
+				strcmp(hint, "image_data") == 0 ||  // Deprecated.
+				strcmp(hint, "icon_data") == 0) {  // Even more deprecated.
 			ret = sd_bus_message_enter_container(msg, 'v', "(iiibiiay)");
 			if (ret < 0) {
 				return ret;


### PR DESCRIPTION
This should hopefully finish off icon support for real. Tested `image-path` with notify-send.

![screenshot_2019-09-09-112733](https://user-images.githubusercontent.com/201439/64544346-d93cbb80-d2f4-11e9-9ee8-b421df5fee7a.png)

Fixes #186. Fixes #180.