### PR TITLE
install a systemd user service unit

### DIFF
--- a/contrib/systemd/mako.service
+++ b/contrib/systemd/mako.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=A lightweight Wayland notification daemon
+Documentation=man:mako(1)
+PartOf=wayland-session.target
+
+[Service]
+Type=dbus
+ExecStart=/usr/bin/mako
+BusName=org.freedesktop.Notifications
+
+[Install]
+WantedBy=wayland-session.target

--- a/contrib/systemd/mako.service.in
+++ b/contrib/systemd/mako.service.in
@@ -5,8 +5,8 @@ PartOf=wayland-session.target
 
 [Service]
 Type=dbus
-ExecStart=/usr/bin/mako
 BusName=org.freedesktop.Notifications
+ExecStart=@bindir@/mako
 
 [Install]
 WantedBy=wayland-session.target

--- a/contrib/systemd/meson.build
+++ b/contrib/systemd/meson.build
@@ -2,6 +2,11 @@ systemd = dependency('systemd', required: get_option('systemd'))
 
 if systemd.found()
   user_units_dir = systemd.get_pkgconfig_variable('systemduserunitdir')
-  install_data('mako.service',
-    install_dir: user_units_dir)
+
+  configure_file(
+    configuration: conf_data,
+    input: 'mako.service.in',
+    output: '@BASENAME@',
+    install_dir: user_units_dir
+  )
 endif

--- a/contrib/systemd/meson.build
+++ b/contrib/systemd/meson.build
@@ -1,0 +1,7 @@
+systemd = dependency('systemd', required: get_option('systemd'))
+
+if systemd.found()
+  user_units_dir = systemd.get_pkgconfig_variable('systemduserunitdir')
+  install_data('mako.service',
+    install_dir: user_units_dir)
+endif

--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,6 @@ endif
 
 subdir('contrib/apparmor')
 subdir('contrib/completions')
-subdir('contrib/systemd')
 subdir('protocol')
 
 src_files = [
@@ -102,6 +101,8 @@ configure_file(
 	output: '@BASENAME@',
 	install_dir: datadir + '/dbus-1/services',
 )
+
+subdir('contrib/systemd')
 
 scdoc = find_program('scdoc', required: get_option('man-pages'))
 

--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,7 @@ endif
 
 subdir('contrib/apparmor')
 subdir('contrib/completions')
+subdir('contrib/systemd')
 subdir('protocol')
 
 src_files = [

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,4 @@ option('icons', type: 'feature', value: 'auto', description: 'Enable icon suppor
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('zsh-completions', type: 'boolean', value: false, description: 'Install zsh completions')
 option('apparmor', type: 'boolean', value: 'false', description: 'Install AppArmor profile')
+option('systemd', type: 'feature', value: 'auto', description: 'Install systemd user service unit')


### PR DESCRIPTION
add a systemd --user unit/service file, so that one can run mako as a
--user systemd service. when the service is enabled, mako will start
when the wayland-session.target is started.
    
this feature is automatically enabled if systemd is found, but can be disabled
with -Dsystemd=disabled.


