### PR TITLE
Support choosing a notification action with 'makoctl menu'

### DIFF
--- a/makoctl
+++ b/makoctl
@@ -8,6 +8,8 @@ usage() {
 	echo "  invoke [-n id] [action]  Invoke an action on the notification"
 	echo "                           with the given id, or the last"
 	echo "                           notification if none is given"
+	echo "  menu [prog] [arg ...]    Use [prog] [args ...] to select one"
+	echo "                           notification action to be invoked"
 	echo "  list                     List notifications"
 	echo "  reload                   Reload the configuration file"
 	echo "  help                     Show this help"
@@ -52,6 +54,22 @@ case "$1" in
 	fi
 
 	call InvokeAction "us" "$id" "$action"
+	;;
+"menu")
+	shift 1
+	if array="$(call ListNotifications | jq -re '.data[0][0].actions.data | if length > 0 then . else false end')"; then
+		sel="$(jq -rn "$array|values[]" | "$@")"
+		sel="$(jq -rn --arg sel "$sel" "$array|to_entries[]|select(.value == \$sel).key")"
+		if [ -z "$sel" ]; then
+			echo >&2 "$0: No action selected"
+			exit 1
+		else
+			call InvokeAction "us" 0 "$sel"
+		fi
+	else
+		echo >&2 "$0: No actions found"
+		exit 1
+	fi
 	;;
 "list")
 	call ListNotifications

--- a/makoctl
+++ b/makoctl
@@ -57,6 +57,10 @@ case "$1" in
 	;;
 "menu")
 	shift 1
+	if ! type -p jq > /dev/null; then
+		echo >&2 "$0: jq is required to use 'menu'"
+		exit 1
+	fi
 	if array="$(call ListNotifications | jq -re '.data[0][0].actions.data | if length > 0 then . else false end')"; then
 		sel="$(jq -rn "$array|values[]" | "$@")"
 		sel="$(jq -rn --arg sel "$sel" "$array|to_entries[]|select(.value == \$sel).key")"

--- a/makoctl.1.scd
+++ b/makoctl.1.scd
@@ -26,6 +26,21 @@ Sends IPC commands to the running mako daemon via dbus.
 	Invokes an action on the first notification. If _action_ is not specified,
 	invokes the default action.
 
+*menu* [program] [argument ...]
+	Use a program to select an action on the first notification. The list of
+	actions are joined on newlines and passed to _program_. The program should
+	write the selected action to stdout. If an action is given, this action
+	will be invoked.
+
+	If no action is found, or no action is selected, _makoctl_ will return non-zero.
+
+	Examples:
+
+		```
+		makoctl menu dmenu -p 'Select Action: '
+		makoctl menu wofi -d -p 'Choose Action: '
+		```
+
 *list*
 	Retrieve a list of current notifications.
 


### PR DESCRIPTION
Requires `jq`, alternative to #194. Would close #4. 