### PR TITLE
Add support for tracking multiple touches (fixes #175)

### DIFF
--- a/include/wayland.h
+++ b/include/wayland.h
@@ -4,6 +4,8 @@
 #include <stdbool.h>
 #include <wayland-client-protocol.h>
 
+#define MAX_TOUCHPOINTS 10
+
 struct mako_state;
 
 struct mako_output {
@@ -30,7 +32,9 @@ struct mako_seat {
 
 	struct {
 		struct wl_touch *wl_touch;
-		int32_t x, y;
+		struct {
+			int32_t x, y;
+		} pts[MAX_TOUCHPOINTS];
 	} touch;
 };
 

--- a/wayland.c
+++ b/wayland.c
@@ -100,16 +100,18 @@ static void touch_handle_motion(void *data, struct wl_touch *wl_touch,
 		uint32_t time, int32_t id,
 		wl_fixed_t surface_x, wl_fixed_t surface_y) {
 	struct mako_seat *seat = data;
-	seat->touch.x = wl_fixed_to_int(surface_x);
-	seat->touch.y = wl_fixed_to_int(surface_y);
+	if (id >= MAX_TOUCHPOINTS) return;
+	seat->touch.pts[id].x = wl_fixed_to_int(surface_x);
+	seat->touch.pts[id].y = wl_fixed_to_int(surface_y);
 }
 
 static void touch_handle_down(void *data, struct wl_touch *wl_touch,
 		uint32_t serial, uint32_t time, struct wl_surface *sfc, int32_t id,
 		wl_fixed_t surface_x, wl_fixed_t surface_y) {
 	struct mako_seat *seat = data;
-	seat->touch.x = wl_fixed_to_int(surface_x);
-	seat->touch.y = wl_fixed_to_int(surface_y);
+	if (id >= MAX_TOUCHPOINTS) return;
+	seat->touch.pts[id].x = wl_fixed_to_int(surface_x);
+	seat->touch.pts[id].y = wl_fixed_to_int(surface_y);
 }
 
 static void touch_handle_up(void *data, struct wl_touch *wl_touch,
@@ -118,8 +120,9 @@ static void touch_handle_up(void *data, struct wl_touch *wl_touch,
 	struct mako_state *state = seat->state;
 
 	struct mako_notification *notif;
+	if (id >= MAX_TOUCHPOINTS) return;
 	wl_list_for_each(notif, &state->notifications, link) {
-		if (hotspot_at(&notif->hotspot, seat->touch.x, seat->touch.y)) {
+		if (hotspot_at(&notif->hotspot, seat->touch.pts[id].x, seat->touch.pts[id].y)) {
 			notification_handle_touch(notif);
 			break;
 		}

--- a/wayland.c
+++ b/wayland.c
@@ -100,7 +100,9 @@ static void touch_handle_motion(void *data, struct wl_touch *wl_touch,
 		uint32_t time, int32_t id,
 		wl_fixed_t surface_x, wl_fixed_t surface_y) {
 	struct mako_seat *seat = data;
-	if (id >= MAX_TOUCHPOINTS) return;
+	if (id >= MAX_TOUCHPOINTS) {
+		return;
+	}
 	seat->touch.pts[id].x = wl_fixed_to_int(surface_x);
 	seat->touch.pts[id].y = wl_fixed_to_int(surface_y);
 }
@@ -109,7 +111,9 @@ static void touch_handle_down(void *data, struct wl_touch *wl_touch,
 		uint32_t serial, uint32_t time, struct wl_surface *sfc, int32_t id,
 		wl_fixed_t surface_x, wl_fixed_t surface_y) {
 	struct mako_seat *seat = data;
-	if (id >= MAX_TOUCHPOINTS) return;
+	if (id >= MAX_TOUCHPOINTS) {
+		return;
+	}
 	seat->touch.pts[id].x = wl_fixed_to_int(surface_x);
 	seat->touch.pts[id].y = wl_fixed_to_int(surface_y);
 }
@@ -120,7 +124,9 @@ static void touch_handle_up(void *data, struct wl_touch *wl_touch,
 	struct mako_state *state = seat->state;
 
 	struct mako_notification *notif;
-	if (id >= MAX_TOUCHPOINTS) return;
+	if (id >= MAX_TOUCHPOINTS) {
+		return;
+	}
 	wl_list_for_each(notif, &state->notifications, link) {
 		if (hotspot_at(&notif->hotspot, seat->touch.pts[id].x, seat->touch.pts[id].y)) {
 			notification_handle_touch(notif);


### PR DESCRIPTION
To keep the code simple I used an array with max capacity 10 for all touchpoints since I couldn't think of any simple way to implement a linked list or map.

Hopefully it's reasonable enough to assume people aren't dismissing notifications with more than 10 fingers (or even more than 5).

It's now anyhow possible to swipe away all your notifications with five carefully placed fingers :raised_hand_with_fingers_splayed:.

Fixes #175.