### PR TITLE
README: Added package dependencies for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Install dependencies:
 * scdoc (optional, for man pages)
 * jq (optional, runtime dependency)
 
+Required packages for the dependencies on Debian (Unstable):
+
+* `meson`
+* `libwayland-dev`
+* `wayland-protocols`
+* `libcairo2-pango-ocaml-dev`
+* `libcairo2-dev`
+* `libsystemd-dev` or `libelogind-dev`
+* `libgdk-pixbuf2.0-dev`
+* `scdoc` (optional, for man pages)
+* `jq`(optional, runtime dependency)
+
 Then run:
 
 ```shell


### PR DESCRIPTION
The idea is to simplify the build process for users of certain distros so they do not search on their own for the right packages.

For example, `meson` complained about missing the `wayland-client` library, so I have installed every package having `wayland-client` in their name, but the required package was `libwayland-dev`.
Similar with `pango`.