### PR TITLE
Allow access to icons in AppArmor profile

### DIFF
--- a/contrib/apparmor/fr.emersion.Mako
+++ b/contrib/apparmor/fr.emersion.Mako
@@ -3,6 +3,7 @@
 profile fr.emersion.Mako /usr/bin/mako {
   #include <abstractions/base>
   #include <abstractions/fonts>
+  #include <abstractions/freedesktop.org>
   #include <abstractions/wayland>
 
   #include <abstractions/dbus-strict>


### PR DESCRIPTION
Standard icons from /usr/share/icons weren't displayed by mako
because AppArmor denied access.  Include abstractions/freedesktop.org
which grants access to icons.

Closes: #206