### PR TITLE
Fix: POSIX 'type' does not require '-p'

### DIFF
--- a/makoctl
+++ b/makoctl
@@ -57,7 +57,7 @@ case "$1" in
 	;;
 "menu")
 	shift 1
-	if ! type -p jq > /dev/null; then
+	if ! type jq > /dev/null; then
 		echo >&2 "$0: jq is required to use 'menu'"
 		exit 1
 	fi


### PR DESCRIPTION
I should have caught this months ago.

---

Tangential: Definitely ping me if any issues get reported on `menu` now that it is in a release. I'll keep a close eye on issues the next week or two at least.