### PR TITLE
Add `makoctl set`

### DIFF
--- a/config.c
+++ b/config.c
@@ -508,6 +508,13 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	return false;
 }
 
+bool apply_global_option(struct mako_config *config, const char *name,
+		const char *value) {
+	struct mako_criteria *global = global_criteria(config);
+	return apply_style_option(&global->style, name, value) ||
+		apply_config_option(config, name, value);
+}
+
 static bool file_exists(const char *path) {
 	return path && access(path, R_OK) != -1;
 }
@@ -676,9 +683,6 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{0},
 	};
 
-	struct mako_criteria *root_criteria =
-		wl_container_of(config->criteria.next, root_criteria, link);
-
 	optind = 1;
 	char *config_arg = NULL;
 	while (1) {
@@ -713,8 +717,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		}
 
 		const char *name = long_options[option_index].name;
-		if (!apply_style_option(&root_criteria->style, name, optarg)
-				&& !apply_config_option(config, name, optarg)) {
+		if (!apply_global_option(config, name, optarg)) {
 			fprintf(stderr, "Failed to parse option '%s'\n", name);
 			return -1;
 		}

--- a/include/config.h
+++ b/include/config.h
@@ -100,5 +100,7 @@ bool apply_superset_style(
 int parse_config_arguments(struct mako_config *config, int argc, char **argv);
 int load_config_file(struct mako_config *config, char *config_arg);
 int reload_config(struct mako_config *config, int argc, char **argv);
+bool apply_global_option(struct mako_config *config, const char *name,
+	const char *value);
 
 #endif

--- a/makoctl
+++ b/makoctl
@@ -12,12 +12,13 @@ usage() {
 	echo "                           notification action to be invoked"
 	echo "  list                     List notifications"
 	echo "  reload                   Reload the configuration file"
+	echo "  set <key>=<value>        Set a global configuration option"
 	echo "  help                     Show this help"
 }
 
 call() {
 	busctl -j --user call org.freedesktop.Notifications /fr/emersion/Mako \
-		fr.emersion.Mako "$@"
+		fr.emersion.Mako -- "$@"
 }
 
 if [ $# -eq 0 ] || [ $# -gt 5 ]; then
@@ -80,6 +81,19 @@ case "$1" in
 	;;
 "reload")
 	call Reload
+	;;
+"set")
+	if [ $# -lt 2 ]; then
+		echo >&2 "makoctl: missing argument for 'set'"
+		exit 1
+	fi
+	name="${2%%'='*}"
+	value="${2#*'='}"
+	if [ "$2" = "$name" ]; then
+		echo >&2 "makoctl: missing '=' in argument for 'set'"
+		exit 1
+	fi
+	call SetConfigOption "ss" "$name" "$value"
 	;;
 "help"|"--help"|"-h")
 	usage

--- a/makoctl.1.scd
+++ b/makoctl.1.scd
@@ -47,6 +47,11 @@ Sends IPC commands to the running mako daemon via dbus.
 *reload*
 	Reloads the configuration file.
 
+*set* <key>=<value>
+	Set a global configuration option.
+
+	Reloading the config will discard options set like this.
+
 *help, -h, --help*
 	Show help message and quit.
 


### PR DESCRIPTION
This can be used for instance to implement a "do not disturb" mode:

    makoctl set invisible=1
    makoctl set invisible=0

This is similar to `swaymsg <command>`.

Only global configuration options are supported for now. Criteria requires more discussion.

References: https://github.com/emersion/mako/issues/138