### PR TITLE
Fix all the border drawing things

### DIFF
--- a/render.c
+++ b/render.c
@@ -168,12 +168,6 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	}
 
 	int notif_background_width = notif_width - style->border_size;
-	int progress_width = notif_background_width * progress / 100;
-	if (progress_width < 0) {
-		progress_width = 0;
-	} else if (progress_width > notif_background_width) {
-		progress_width = notif_background_width;
-	}
 
 	// Define the shape of the notification. The stroke is drawn centered on
 	// the edge of the fill, so we need to inset the shape by half the
@@ -194,14 +188,24 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	cairo_path_t *border_path = cairo_copy_path(cairo);
 
 	// Render progress. We need to render this as a normal rectangle, but clip
-	// it to the rounded rectangle we drew for the background.
+	// it to the rounded rectangle we drew for the background. We also inset it
+	// a bit further so that 0 and 100 percent are aligned to the inside edge
+	// of the border and we can actually see the whole range.
+	int progress_width =
+		(notif_background_width - style->border_size) * progress / 100;
+	if (progress_width < 0) {
+		progress_width = 0;
+	} else if (progress_width > notif_background_width) {
+		progress_width = notif_background_width - style->border_size;
+	}
+
 	cairo_save(cairo);
 	cairo_clip(cairo);
 	cairo_set_operator(cairo, style->colors.progress.operator);
 	set_source_u32(cairo, style->colors.progress.value);
 	set_rounded_rectangle(cairo,
-			offset_x + style->border_size / 2.0,
-			offset_y + style->border_size / 2.0,
+			offset_x + style->border_size,
+			offset_y + style->border_size,
 			progress_width,
 			notif_height - style->border_size,
 			scale, 0);

--- a/render.c
+++ b/render.c
@@ -45,6 +45,7 @@ static void set_rounded_rectangle(cairo_t *cairo, double x, double y, double wid
 	y *= scale;
 	width *= scale;
 	height *= scale;
+	radius *= scale;
 	double degrees = M_PI / 180.0;
 
 	if (width < radius * 2) {

--- a/render.c
+++ b/render.c
@@ -48,14 +48,6 @@ static void set_rounded_rectangle(cairo_t *cairo, double x, double y, double wid
 	radius *= scale;
 	double degrees = M_PI / 180.0;
 
-	if (width < radius * 2) {
-		width = radius * 2;
-	}
-
-	if (height < radius * 2) {
-		height = radius * 2;
-	}
-
 	cairo_new_sub_path(cairo);
 	cairo_arc(cairo, x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees);
 	cairo_arc(cairo, x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees);
@@ -165,6 +157,10 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	int notif_height = text_height + border_size + padding_height;
 	if (icon != NULL && icon->height > text_height) {
 		notif_height = icon->height + border_size + padding_height;
+	}
+
+	if (notif_height < radius * 2) {
+		notif_height = radius * 2 + border_size;
 	}
 
 	int notif_background_width = notif_width - style->border_size;


### PR DESCRIPTION
This fixes several border drawing bugs that I discovered while working on #214:
- Borders now clip the background and progress to themselves, so there is no overlap with translucent colors.
- The progress is no longer drawn as a nested roundrect but clipped to the background instead, resulting in a perfect edge.
- The border radius is now scaled correctly.
- The height of notifications is calculated correctly when it needs to be adjusted by the radius.

Fixes #214.

![All the things](https://user-images.githubusercontent.com/201439/72224636-a298db00-354a-11ea-8202-800d140d029e.png)