### PR TITLE
Add a history buffer for expired notifications

### DIFF
--- a/config.c
+++ b/config.c
@@ -55,6 +55,7 @@ void init_default_config(struct mako_config *config) {
 	config->layer = ZWLR_LAYER_SHELL_V1_LAYER_TOP;
 
 	config->max_visible = 5;
+	config->max_history = 5;
 	config->sort_criteria = MAKO_SORT_CRITERIA_TIME;
 	config->sort_asc = 0;
 
@@ -119,6 +120,7 @@ void init_default_style(struct mako_style *style) {
 
 	style->group_criteria_spec.none = true;
 	style->invisible = false;
+	style->history = true;
 
 	// Everything in the default config is explicitly specified.
 	memset(&style->spec, true, sizeof(struct mako_style_spec));
@@ -274,6 +276,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 		target->spec.invisible = true;
 	}
 
+	if (style->spec.history) {
+		target->history = style->history;
+		target->spec.history = true;
+	}
+
 	if (style->border_radius) {
 		target->border_radius = style->border_radius;
 		target->spec.border_radius = true;
@@ -300,6 +307,7 @@ bool apply_superset_style(
 	target->spec.default_timeout = true;
 	target->spec.markup = true;
 	target->spec.actions = true;
+	target->spec.history = true;
 	target->spec.format = true;
 
 	free(target->format);
@@ -337,6 +345,7 @@ bool apply_superset_style(
 
 		target->markup |= style->markup;
 		target->actions |= style->actions;
+		target->history |= style->history;
 
 		// We do need to be safe about this one though.
 		if (style->spec.format) {
@@ -371,6 +380,8 @@ static bool apply_config_option(struct mako_config *config, const char *name,
 		const char *value) {
 	if (strcmp(name, "max-visible") == 0) {
 		return parse_int(value, &config->max_visible);
+	} else if (strcmp(name, "max-history") == 0) {
+		return parse_int(value, &config->max_history);
 	} else if (strcmp(name, "output") == 0) {
 		free(config->output);
 		config->output = strdup(value);
@@ -496,6 +507,8 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 			parse_criteria_spec(value, &style->group_criteria_spec);
 	} else if (strcmp(name, "invisible") == 0) {
 		return spec->invisible = parse_boolean(value, &style->invisible);
+	} else if (strcmp(name, "history") == 0) {
+		return spec->history = parse_boolean(value, &style->history);
 	} else if (strcmp(name, "border-radius") == 0) {
 		spec->border_radius = parse_int(value, &style->border_radius);
 		if (spec->border_radius && spec->padding) {
@@ -673,6 +686,8 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"actions", required_argument, 0, 0},
 		{"format", required_argument, 0, 0},
 		{"max-visible", required_argument, 0, 0},
+		{"max-history", required_argument, 0, 0},
+		{"history", required_argument, 0, 0},
 		{"default-timeout", required_argument, 0, 0},
 		{"ignore-timeout", required_argument, 0, 0},
 		{"output", required_argument, 0, 0},

--- a/contrib/completions/zsh/_mako
+++ b/contrib/completions/zsh/_mako
@@ -20,7 +20,9 @@ _arguments \
     '--actions[Applications may request an action to be associated with activating a notification. Disabling this will cause mako to ignore these requests.]:action enabled:(0 1)' \
     '--format[Format string.]:format:' \
     '--hidden-format[Format string.]:format:' \
-    '--max-visible[Max number of visible notifications.]:visible notification:' \
+    '--max-visible[Max number of visible notifications.]:visible notifications:' \
+    '--max-history[Max size of history buffer.]:historical notifications:' \
+    '--history[Add expired notification to history.]:history:' \
     '--default-timeout[Default timeout in milliseconds.]:timeout (ms):' \
     '--ignore-timeout[If set, mako will ignore the expire timeout sent by notifications and use the one provided by default-timeout instead.]:Use default timeout:(0 1)' \
     '--output[Show notifications on this output.]:name:' \

--- a/contrib/completions/zsh/_makoctl
+++ b/contrib/completions/zsh/_makoctl
@@ -4,6 +4,7 @@ local -a makoctl_cmds
 
 makoctl_cmds=(
 	'dismiss:Dismisses notification (first by default)'
+	'restore:Restore the most recently expired notification from the history buffer'
 	'invoke:Invokes an action on the first notification. If action is not specified, invokes the default action'
 	'list:Retrieve a list of current notifications'
 	'reload:Reloads the configuration file'

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -78,6 +78,25 @@ done:
 	return sd_bus_reply_method_return(msg, "");
 }
 
+static int handle_restore_action(sd_bus_message *msg, void *data,
+		sd_bus_error *ret_error) {
+	struct mako_state *state = data;
+
+	if (wl_list_empty(&state->history)) {
+		goto done;
+	}
+
+	struct mako_notification *notif =
+		wl_container_of(state->history.next, notif, link);
+	wl_list_remove(&notif->link);
+
+	insert_notification(state, notif);
+	set_dirty(state);
+
+done:
+	return sd_bus_reply_method_return(msg, "");
+}
+
 static int handle_list_notifications(sd_bus_message *msg, void *data,
 		sd_bus_error *ret_error) {
 	struct mako_state *state = data;
@@ -260,6 +279,7 @@ static const sd_bus_vtable service_vtable[] = {
 	SD_BUS_METHOD("DismissAllNotifications", "", "", handle_dismiss_all_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("DismissLastNotification", "", "", handle_dismiss_last_notification, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("InvokeAction", "us", "", handle_invoke_action, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("RestoreNotification", "", "", handle_restore_action, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("ListNotifications", "", "aa{sv}", handle_list_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("Reload", "", "", handle_reload, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("SetConfigOption", "ss", "", handle_set_config_option, SD_BUS_VTABLE_UNPRIVILEGED),

--- a/include/config.h
+++ b/include/config.h
@@ -25,7 +25,7 @@ enum mako_sort_criteria {
 struct mako_style_spec {
 	bool width, height, margin, padding, border_size, border_radius, font,
 		markup, format, actions, default_timeout, ignore_timeout, icons,
-		max_icon_size, icon_path, group_criteria_spec, invisible;
+		max_icon_size, icon_path, group_criteria_spec, invisible, history;
 
 	struct {
 		bool background, text, border, progress;
@@ -65,12 +65,14 @@ struct mako_style {
 	struct mako_criteria_spec group_criteria_spec;
 
 	bool invisible; // Skipped during render, doesn't count toward max_visible
+	bool history;
 };
 
 struct mako_config {
 	struct wl_list criteria; // mako_criteria::link
 
 	int32_t max_visible;
+	int32_t max_history;
 	char *output;
 	enum zwlr_layer_shell_v1_layer layer;
 	uint32_t anchor;

--- a/include/mako.h
+++ b/include/mako.h
@@ -46,6 +46,7 @@ struct mako_state {
 
 	uint32_t last_id;
 	struct wl_list notifications; // mako_notification::link
+	struct wl_list history; // mako_notification::link
 
 	int argc;
 	char **argv;

--- a/main.c
+++ b/main.c
@@ -40,6 +40,8 @@ static const char usage[] =
 	"      --format <format>               Format string.\n"
 	"      --hidden-format <format>        Format string.\n"
 	"      --max-visible <n>               Max number of visible notifications.\n"
+	"      --max-history <n>               Max size of history buffer.\n"
+	"      --history <0|1>                 Add expired notificatinos to history.\n"
 	"      --sort <sort_criteria>          Sorts incoming notifications by time\n"
 	"                                      and/or priority in ascending(+) or\n"
 	"                                      descending(-) order.\n"
@@ -65,12 +67,16 @@ static bool init(struct mako_state *state) {
 		return false;
 	}
 	wl_list_init(&state->notifications);
+	wl_list_init(&state->history);
 	return true;
 }
 
 static void finish(struct mako_state *state) {
 	struct mako_notification *notif, *tmp;
 	wl_list_for_each_safe(notif, tmp, &state->notifications, link) {
+		destroy_notification(notif);
+	}
+	wl_list_for_each_safe(notif, tmp, &state->history, link) {
 		destroy_notification(notif);
 	}
 	finish_event_loop(&state->event_loop);

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -22,6 +22,13 @@ Empty lines and lines that begin with # are ignored.
 
 	Default: 5
 
+*max-history* = _n_
+	Set maximum number of expired notifications to keep in the history
+	buffer to _n_. If the buffer is full, newly expired notifications
+	replace the oldest ones. If 0, history is disabled.
+
+	Default: 5
+
 *sort* = _+/-time_ | _+/-priority_
 	Sorts incoming notifications by time and/or priority in ascending(+)
 	or descending(-) order.
@@ -147,6 +154,13 @@ Empty lines and lines that begin with # are ignored.
 *actions* = 0|1
 	Applications may request an action to be associated with activating a
 	notification. Disabling this will cause mako to ignore these requests.
+
+	Default: 1
+
+*history* = 0|1
+	If set, mako will save notifications that have reached their timeout
+	into the history buffer instead of immediately deleting them.
+	_max-history_ determines the size of the history buffer.
 
 	Default: 1
 

--- a/makoctl
+++ b/makoctl
@@ -5,6 +5,8 @@ usage() {
 	echo ""
 	echo "Commands:"
 	echo "  dismiss [-a|--all]       Dismiss the last or all notifications"
+	echo "  restore                  Restore the most recently expired"
+	echo "                           notification from the history buffer"
 	echo "  invoke [-n id] [action]  Invoke an action on the notification"
 	echo "                           with the given id, or the last"
 	echo "                           notification if none is given"
@@ -55,6 +57,9 @@ case "$1" in
 	fi
 
 	call InvokeAction "us" "$id" "$action"
+	;;
+"restore")
+	call RestoreNotification
 	;;
 "menu")
 	shift 1

--- a/makoctl.1.scd
+++ b/makoctl.1.scd
@@ -22,6 +22,9 @@ Sends IPC commands to the running mako daemon via dbus.
 	*-a, --all*
 		Dismiss all notifications.
 
+*restore*
+	Restores the most recently expired notification from the history buffer.
+
 *invoke* [action]
 	Invokes an action on the first notification. If _action_ is not specified,
 	invokes the default action.


### PR DESCRIPTION
Notifications that have reached their timeout may
be added to a history buffer, displacing the
oldest stored notification if the buffer is full.

The buffer's size is controlled by the global
`max-history` setting. The `history` style
determines if a notification is saved to the
history buffer when it expires.

A new `RestoreNotification` dbus method restores
the most recent notification from the history buffer.

Restored notifications must be dismissed manually.

Closes: https://github.com/emersion/mako/issues/91