### PR TITLE
Fix makoctl -gt 5 arguments limit #221

### DIFF
--- a/makoctl
+++ b/makoctl
@@ -21,7 +21,7 @@ call() {
 		fr.emersion.Mako -- "$@"
 }
 
-if [ $# -eq 0 ] || [ $# -gt 5 ]; then
+if [ $# -eq 0 ]; then
    usage
    exit 1
 fi


### PR DESCRIPTION
Closes: https://github.com/emersion/mako/issues/221