### PR TITLE
Implement `do-not-disturb` via `max_visible=0`

### DIFF
--- a/render.c
+++ b/render.c
@@ -258,6 +258,11 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 	int pending_bottom_margin = 0;
 	struct mako_notification *notif;
 	wl_list_for_each(notif, &state->notifications, link) {
+		if (config->max_visible >= 0 &&
+				visible_count >= (size_t)config->max_visible) {
+			break;
+		}
+
 		// Note that by this point, everything in the style is guaranteed to
 		// be specified, so we don't need to check.
 		struct mako_style *style = &notif->style;
@@ -300,15 +305,10 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 			// single entity for this purpose.
 			++visible_count;
 		}
-
-		if (config->max_visible >= 0 &&
-				visible_count >= (size_t)config->max_visible) {
-			break;
-		}
 	}
 
 	size_t count = wl_list_length(&state->notifications);
-	if (count > i) {
+	if (count > i && config->max_visible > 0) {
 		// Apply the hidden_style on top of the global style. This has to be
 		// done here since this notification isn't "real" and wasn't processed
 		// by apply_each_criteria.


### PR DESCRIPTION
Dunst has a very nice feature of being able to temporarily silence all notifications. I'd like to be able to have the same "do not disturb" mode with mako as well.

I saw you implemented `makoctl set` command to temporarily change config values, but it seems there is no config to stop or start mako (unless I'm missing something obvious)?

Continuing the logic, instead of implementing a completely new config, I was thinking we could make use of the existing `max-visible` setting?

In this case, `makoctl set max-visible=0` will enable "do not disturb" mode, and `makoctl set max-visible=5` will disable it.

I now treat `max-visible=0` specially to not show `(1 more)` message, but otherwise the patch proved to be quite simple.

What do you think, about the idea, and the code in general?