### PR TITLE
Remove the bottom margin for the last notification

### DIFF
--- a/render.c
+++ b/render.c
@@ -310,9 +310,9 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 
 		total_height += notif_height;
 		pending_bottom_margin = style->margin.bottom;
-                if (i == count){
-	            pending_bottom_margin = 0;
-                }
+		if (i == count){
+			pending_bottom_margin = 0;
+		}
 
 		if (notif->group_index < 1) {
 			// If the notification is ungrouped, or is the first in a group, it

--- a/render.c
+++ b/render.c
@@ -274,6 +274,7 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 	int total_height = 0;
 	int pending_bottom_margin = 0;
 	struct mako_notification *notif;
+	size_t count = wl_list_length(&state->notifications);
 	wl_list_for_each(notif, &state->notifications, link) {
 		// Note that by this point, everything in the style is guaranteed to
 		// be specified, so we don't need to check.
@@ -309,6 +310,9 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 
 		total_height += notif_height;
 		pending_bottom_margin = style->margin.bottom;
+                if (i == count){
+	            pending_bottom_margin = 0;
+                }
 
 		if (notif->group_index < 1) {
 			// If the notification is ungrouped, or is the first in a group, it
@@ -324,7 +328,6 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 		}
 	}
 
-	size_t count = wl_list_length(&state->notifications);
 	if (count > i) {
 		// Apply the hidden_style on top of the global style. This has to be
 		// done here since this notification isn't "real" and wasn't processed
@@ -361,7 +364,7 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 		finish_style(&style);
 
 		total_height += hidden_height;
-		pending_bottom_margin = style.margin.bottom;
+		pending_bottom_margin = 0;
 	}
 
 	return total_height + pending_bottom_margin;


### PR DESCRIPTION
If the notification is the last one, the margin is set to `0`.
This is minimal and complement f8ddfe048072d85e1d78cb486a56634b1b93e200 in response to #225, (and potentially allows a nice notification ovelap too). The old behavior is restored by setting negative top and bottom margins values to the border width value.

Overlap example: `margin=-10,0,-10,0` 
![2020-01-30-160623_screenshot](https://user-images.githubusercontent.com/33178690/73461634-cb0e3b00-437a-11ea-9846-37e35e771b6a.png)

Fixes #225 