### PR TITLE
Timeout = 0, max-visible = 0

### DIFF
--- a/config.c
+++ b/config.c
@@ -108,7 +108,7 @@ void init_default_style(struct mako_style *style) {
 	style->format = strdup("<b>%s</b>\n%b");
 
 	style->actions = true;
-	style->default_timeout = 0;
+	style->default_timeout = -1;
 	style->ignore_timeout = false;
 
 	style->colors.background = 0x285577FF;

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -377,7 +377,7 @@ static int handle_notify(sd_bus_message *msg, void *data,
 		expire_timeout = notif->style.default_timeout;
 	}
 
-	if (expire_timeout > 0) {
+	if (expire_timeout >= 0) {
 		notif->timer = add_event_loop_timer(&state->event_loop, expire_timeout,
 			handle_notification_timer, notif);
 	}

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -160,9 +160,9 @@ Empty lines and lines that begin with # are ignored.
 
 *default-timeout* = _timeout_
 	Set the default timeout to _timeout_ in milliseconds. To disable the
-	timeout, set it to zero.
+	timeout, set it to minus one.
 
-	Default: 0
+	Default: -1
 
 *ignore-timeout* = 0|1
 	If set, mako will ignore the expire timeout sent by notifications and use

--- a/render.c
+++ b/render.c
@@ -275,6 +275,12 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 	int pending_bottom_margin = 0;
 	struct mako_notification *notif;
 	wl_list_for_each(notif, &state->notifications, link) {
+
+		if (config->max_visible >= 0 &&
+				visible_count >= (size_t)config->max_visible) {
+			break;
+		}
+
 		// Note that by this point, everything in the style is guaranteed to
 		// be specified, so we don't need to check.
 		struct mako_style *style = &notif->style;
@@ -318,10 +324,6 @@ int render(struct mako_state *state, struct pool_buffer *buffer, int scale) {
 			++visible_count;
 		}
 
-		if (config->max_visible >= 0 &&
-				visible_count >= (size_t)config->max_visible) {
-			break;
-		}
 	}
 
 	size_t count = wl_list_length(&state->notifications);


### PR DESCRIPTION
Now works with zero timeout as it should be, it's more intuitively.

Before it with _max-visible=0_ one notification was showing however. It was equivalent to _max-visible=1._
Now it works with _max-visible=0,_ so all notifications can be hidden.