### PR TITLE
makoctl.1.scd: deindent literal block

### DIFF
--- a/makoctl.1.scd
+++ b/makoctl.1.scd
@@ -36,10 +36,10 @@ Sends IPC commands to the running mako daemon via dbus.
 
 	Examples:
 
-		```
-		makoctl menu dmenu -p 'Select Action: '
-		makoctl menu wofi -d -p 'Choose Action: '
-		```
+```
+makoctl menu dmenu -p 'Select Action: '
+makoctl menu wofi -d -p 'Choose Action: '
+```
 
 *list*
 	Retrieve a list of current notifications.


### PR DESCRIPTION
commit e6a8cadab added an indented literal block that scdoc couldn't
deindent.

  $ scdoc <makoctl.1.scd
  Error at 40:4: Cannot deindent in literal block

Deindenting the block fixes the issue.