### PR TITLE
dbus: Request name async

### DIFF
--- a/dbus/dbus.c
+++ b/dbus/dbus.c
@@ -29,7 +29,7 @@ bool init_dbus(struct mako_state *state) {
 		goto error;
 	}
 
-	ret = sd_bus_request_name(state->bus, service_name, 0);
+	ret = sd_bus_request_name_async(state->bus, NULL, service_name, 0, NULL, NULL);
 	if (ret < 0) {
 		fprintf(stderr, "Failed to acquire service name: %s\n", strerror(-ret));
 		if (ret == -EEXIST) {


### PR DESCRIPTION
If a method call towards mako caused service activation, the activating call would not be answered and simply time out. Switching the name request to be async allows the activating call to be serviced.

Note that notify-send would not display this issue, as it explicitly calls org.freedesktop.DBus.StartServiceByName on startup. A direct org.freedesktop.Notifications.Notify call is needed, such as the one from https://git.sr.ht/~kennylevinsen/poweralertd.