### PR TITLE
criteria: always init its list

### DIFF
--- a/criteria.c
+++ b/criteria.c
@@ -354,6 +354,8 @@ struct mako_criteria *create_criteria_from_notification(
 		return NULL;
 	}
 
+	wl_list_init(&criteria->link);
+
 	memcpy(&criteria->spec, spec, sizeof(struct mako_criteria_spec));
 
 	// We only really need to copy the ones that are in the spec, but it

--- a/notification.c
+++ b/notification.c
@@ -103,7 +103,7 @@ void close_notification(struct mako_notification *notif,
 			notif, &notif->style.group_criteria_spec);
 	if (notif_criteria) {
 		group_notifications(notif->state, notif_criteria);
-		free(notif_criteria);
+		destroy_criteria(notif_criteria);
 	}
 
 	if (!notif->style.history ||


### PR DESCRIPTION
In #244 changing the `free(notif_criteria)` in `close_notifications` to `destroy_criteria`. This was segfaulting, though, because `create_criteria_from_notification` wasn't initializing the list. This seems to fix it.