### PR TITLE
[WIP] Run a command on notification

### DIFF
--- a/config.c
+++ b/config.c
@@ -79,6 +79,7 @@ void finish_config(struct mako_config *config) {
 
 	finish_style(&config->superstyle);
 	finish_style(&config->hidden_style);
+	finish_binding(&config->notify_binding);
 	finish_binding(&config->button_bindings.left);
 	finish_binding(&config->button_bindings.right);
 	finish_binding(&config->button_bindings.middle);
@@ -450,8 +451,7 @@ static bool apply_config_option(struct mako_config *config, const char *name,
 			return false;
 		}
 		return true;
-	} else if (has_prefix(name, "on-button-")
-			|| strcmp(name, "on-touch") == 0) {
+	} else if (has_prefix(name, "on-")) {
 		struct mako_binding binding = {0};
 		if (strcmp(value, "none") == 0) {
 			binding.action = MAKO_BINDING_NONE;
@@ -478,6 +478,8 @@ static bool apply_config_option(struct mako_config *config, const char *name,
 			config->button_bindings.middle = binding;
 		} else if (strcmp(name, "on-touch") == 0) {
 			config->touch_binding = binding;
+		} else if (strcmp(name, "on-notify") == 0) {
+			config->notify_binding = binding;
 		} else {
 			finish_binding(&binding);
 			return false;

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -401,6 +401,8 @@ static int handle_notify(sd_bus_message *msg, void *data,
 	group_notifications(state, notif_criteria);
 	free(notif_criteria);
 
+	notification_execute_binding(notif, &notif->state->config.notify_binding);
+
 	set_dirty(state);
 
 	return sd_bus_reply_method_return(msg, "u", notif->id);

--- a/include/config.h
+++ b/include/config.h
@@ -7,17 +7,23 @@
 #include "types.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
-enum mako_binding {
+enum mako_binding_action {
 	MAKO_BINDING_NONE,
 	MAKO_BINDING_DISMISS,
 	MAKO_BINDING_DISMISS_GROUP,
 	MAKO_BINDING_DISMISS_ALL,
 	MAKO_BINDING_INVOKE_DEFAULT_ACTION,
+	MAKO_BINDING_EXEC,
 };
 
 enum mako_sort_criteria {
 	MAKO_SORT_CRITERIA_TIME = 1,
 	MAKO_SORT_CRITERIA_URGENCY = 2,
+};
+
+struct mako_binding {
+	enum mako_binding_action action;
+	char *command; // for MAKO_BINDING_EXEC
 };
 
 // Represents which fields in the style were specified in this style. All
@@ -84,11 +90,13 @@ struct mako_config {
 	struct mako_style superstyle;
 
 	struct {
-		enum mako_binding left, right, middle;
+		struct mako_binding left, right, middle;
 	} button_bindings;
 
-	enum mako_binding touch;
+	struct mako_binding touch_binding;
 };
+
+void finish_binding(struct mako_binding *binding);
 
 void init_default_config(struct mako_config *config);
 void finish_config(struct mako_config *config);

--- a/include/config.h
+++ b/include/config.h
@@ -83,16 +83,16 @@ struct mako_config {
 	char *output;
 	enum zwlr_layer_shell_v1_layer layer;
 	uint32_t anchor;
-	uint32_t sort_criteria; //enum mako_sort_criteria
+	uint32_t sort_criteria; // enum mako_sort_criteria
 	uint32_t sort_asc;
 
 	struct mako_style hidden_style;
 	struct mako_style superstyle;
 
+	struct mako_binding notify_binding;
 	struct {
 		struct mako_binding left, right, middle;
 	} button_bindings;
-
 	struct mako_binding touch_binding;
 };
 

--- a/include/notification.h
+++ b/include/notification.h
@@ -92,7 +92,7 @@ void notification_handle_button(struct mako_notification *notif, uint32_t button
 	enum wl_pointer_button_state state);
 void notification_handle_touch(struct mako_notification *notif);
 void notification_execute_binding(struct mako_notification *notif,
-	enum mako_binding binding);
+	const struct mako_binding *binding);
 void insert_notification(struct mako_state *state, struct mako_notification *notif);
 int group_notifications(struct mako_state *state, struct mako_criteria *criteria);
 

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -62,8 +62,8 @@ Empty lines and lines that begin with # are ignored.
 # BUTTON AND TOUCH BINDINGS
 
 Specify the action to take per button or touch event. Supported values are
-_none_, _dismiss_, _dismiss-all_, _dismiss-group_, _invoke-default-action_,
-
+_none_, _dismiss_, _dismiss-all_, _dismiss-group_, _invoke-default-action_
+and _exec <command>_.
 
 *on-button-left* = _action_
 	Default: invoke-default-action
@@ -76,7 +76,6 @@ _none_, _dismiss_, _dismiss-all_, _dismiss-group_, _invoke-default-action_,
 
 *on-touch* = _action_
 	Default: dismiss
-
 
 # STYLE OPTIONS
 

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -59,11 +59,11 @@ Empty lines and lines that begin with # are ignored.
 
 	Default: top-right
 
-# BUTTON AND TOUCH BINDINGS
+# BINDINGS
 
-Specify the action to take per button or touch event. Supported values are
-_none_, _dismiss_, _dismiss-all_, _dismiss-group_, _invoke-default-action_
-and _exec <command>_.
+Bindings allow to execute an action when an event is triggered. Supported
+actions are _none_, _dismiss_, _dismiss-all_, _dismiss-group_,
+_invoke-default-action_ and _exec <command>_.
 
 *on-button-left* = _action_
 	Default: invoke-default-action
@@ -76,6 +76,9 @@ and _exec <command>_.
 
 *on-touch* = _action_
 	Default: dismiss
+
+*on-notify* = _action_
+	Default: none
 
 # STYLE OPTIONS
 

--- a/notification.c
+++ b/notification.c
@@ -354,6 +354,15 @@ void notification_execute_binding(struct mako_notification *notif,
 			perror("fork failed");
 			break;
 		} else if (pid == 0) {
+			char id[32];
+			snprintf(id, sizeof(id), "%"PRIu32, notif->id);
+			setenv("id", id, 1);
+
+			unsetenv("desktop_entry");
+			if (notif->desktop_entry != NULL) {
+				setenv("desktop_entry", notif->desktop_entry, 1);
+			}
+
 			// Double-fork to avoid SIGCHLD issues
 			pid = fork();
 			if (pid < 0) {


### PR DESCRIPTION
- [x] `on-notify`
- [x] `exec` action
- [ ] Add access to variables
- [ ] Make bindings a style option

Right now, this works:

```
on-notify=exec [ -n "$desktop_entry" ] && swaymsg [app_id="$desktop_entry"] urgent enable
```

Closes: https://github.com/emersion/mako/issues/38