### PR TITLE
Replace frame callback when surface is closed

### DIFF
--- a/include/mako.h
+++ b/include/mako.h
@@ -35,8 +35,8 @@ struct mako_state {
 	struct mako_output *surface_output;
 	struct zwlr_layer_surface_v1 *layer_surface;
 	struct mako_output *layer_surface_output;
+	struct wl_callback *frame_callback;
 	bool configured;
-	bool frame_pending; // Have we requested a frame callback?
 	bool dirty; // Do we need to redraw?
 	int32_t scale;
 


### PR DESCRIPTION
If our layer shell surface was closed while we had a pending frame
callback, the callback would leak and never fire, and a check on
frame_pending would block any future frame.

Destroy the pending frame callback on surface close and schedule a new
frame in its stead to ensure that requested frames will be drawn.

Closes: https://github.com/emersion/mako/issues/184