### PR TITLE
Reschedule frame if configuration is pending

### DIFF
--- a/wayland.c
+++ b/wayland.c
@@ -276,21 +276,19 @@ static void layer_surface_handle_closed(void *data,
 	wl_surface_destroy(state->surface);
 	state->surface = NULL;
 
-	bool need_reschedule = false;
 	if (state->frame_callback) {
 		wl_callback_destroy(state->frame_callback);
 		state->frame_callback = NULL;
-		need_reschedule = true;
+		state->dirty = true;
 	}
 
 	if (state->configured) {
 		state->configured = false;
 		state->width = state->height = 0;
 		state->dirty = true;
-		need_reschedule = true;
 	}
 
-	if (need_reschedule) {
+	if (state->dirty) {
 		schedule_frame_and_commit(state);
 	}
 }


### PR DESCRIPTION
If a surface is pending configuration, the state is dirty with no frame
callback and no configured flag. If a surface was destroyed in this
state, none of the rescheduling conditions would activate, while the
dirty flag would block all future frame scheduling.

Always schedule a new frame when dirty is set. Also replaces
need_reschedule with state->dirty directly.

Closes: https://github.com/emersion/mako/issues/189