### PR TITLE
Fix some memory leaks

### DIFF
--- a/config.c
+++ b/config.c
@@ -131,6 +131,7 @@ void init_empty_style(struct mako_style *style) {
 }
 
 void finish_style(struct mako_style *style) {
+	free(style->icon_path);
 	free(style->font);
 	free(style->format);
 }

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -399,7 +399,7 @@ static int handle_notify(sd_bus_message *msg, void *data,
 		return -1;
 	}
 	group_notifications(state, notif_criteria);
-	free(notif_criteria);
+	destroy_criteria(notif_criteria);
 
 	set_dirty(state);
 

--- a/types.c
+++ b/types.c
@@ -198,6 +198,7 @@ bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out) {
 		token = strtok_r(NULL, ",", &saveptr);
 	}
 
+	free(components);
 	return true;
 }
 


### PR DESCRIPTION
config.c: mako_style.icon_path needs to be free'd

xdg.c: mako_criteria *notif_criteria needs to be destroyed with
destroy_criteria as it contains owning pointers

types.c: char *components needs to be free'd after being strdup'd

Addresses some of #204
The other leaks seem to be caused in `render_notification` and certainly pango/cairo related.