### PR TITLE
Remove double quotes around variable in service file

### DIFF
--- a/contrib/systemd/mako.service.in
+++ b/contrib/systemd/mako.service.in
@@ -7,7 +7,7 @@ After=graphical-session.target
 [Service]
 Type=dbus
 BusName=org.freedesktop.Notifications
-ExecCondition=/bin/sh -c '[ -n "$WAYLAND_DISPLAY" ]'
+ExecCondition=/bin/sh -c '[ -n $WAYLAND_DISPLAY ]'
 ExecStart=@bindir@/mako
 ExecReload=@bindir@/makoctl reload
 


### PR DESCRIPTION
Fixes https://github.com/emersion/mako/issues/259 on Fedora, would need to be verified on other distros.
