### PR TITLE
scan-build cleanup + allocation fail handling

### DIFF
--- a/criteria.c
+++ b/criteria.c
@@ -383,6 +383,11 @@ ssize_t apply_each_criteria(struct wl_list *criteria_list,
 			notif->style.layer, notif->style.anchor, notif->style.max_visible);
 	}
 
+	if (!notif->surface) {
+		fprintf(stderr, "Couldn't create surface for notification\n");
+		return -1;
+	}
+
 	return match_count;
 }
 

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -249,8 +249,8 @@ static void reapply_config(struct mako_state *state) {
 		destroy_surface(surface);
 	}
 
-	struct mako_notification *notif;
-	wl_list_for_each(notif, &state->notifications, link) {
+	struct mako_notification *notif, *ntmp;
+	wl_list_for_each_safe(notif, ntmp, &state->notifications, link) {
 		// Reset the notifications' grouped state so that if criteria have been
 		// removed they'll separate properly.
 		notif->group_index = -1;
@@ -260,7 +260,10 @@ static void reapply_config(struct mako_state *state) {
 
 		finish_style(&notif->style);
 		init_empty_style(&notif->style);
-		apply_each_criteria(&state->config.criteria, notif);
+		if (apply_each_criteria(&state->config.criteria, notif) == -1) {
+			fprintf(stderr, "Applying criteria failed\n");
+			destroy_notification(notif);
+		}
 
 		// Having to do this for every single notification really hurts... but
 		// it does do The Right Thing (tm).

--- a/include/config.h
+++ b/include/config.h
@@ -99,7 +99,7 @@ struct mako_config {
 	enum mako_binding touch;
 };
 
-void init_default_config(struct mako_config *config);
+int init_default_config(struct mako_config *config);
 void finish_config(struct mako_config *config);
 
 void init_default_style(struct mako_style *style);

--- a/main.c
+++ b/main.c
@@ -101,7 +101,10 @@ int main(int argc, char *argv[]) {
 	wl_list_init(&state.surfaces);
 
 	// This is a bit wasteful, but easier than special-casing the reload.
-	init_default_config(&state.config);
+	if (init_default_config(&state.config) < 0) {
+		fprintf(stderr, "Failed to create default config\n");
+		return -1;
+	}
 	int ret = reload_config(&state.config, argc, argv);
 
 	if (ret < 0) {


### PR DESCRIPTION
This is based on https://github.com/emersion/mako/pull/228

First commit unique to this PR cleans up 3 possible memory leask detected via `scan-build`.

Second commit sprinkles couple of allocation failure handlers into the code.
Though I don't think there's a system with a reasonable use for mako that doesn't use overcommit and actualy allows to have an allocation failure.