### PR TITLE
Improve center alignment

### DIFF
--- a/render.c
+++ b/render.c
@@ -106,8 +106,10 @@ static int render_notification(cairo_t *cairo, struct mako_state *state,
 	int offset_x;
 	if (state->config.anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT) {
 		offset_x = state->width - notif_width - style->margin.right;
-	} else {
+	} else if (state->config.anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT) {
 		offset_x = style->margin.left;
+	} else { // CENTER has nothing to & with, so it's the else case
+		offset_x = (state->width - notif_width) / 2;
 	}
 
 	double text_x = style->padding.left;


### PR DESCRIPTION
Title says all. See attached screenshots for before and after.

Or, probably doesn't. Quick edit^^
So this happens if there's a center alignment and notifications with different widths. This should fix that. Probably more important with the multi-surface stuff, but also a general fix.
![center-align](https://user-images.githubusercontent.com/4039331/80838697-e860d880-8bf9-11ea-8417-e0ac3a89be19.png)
![center-patched](https://user-images.githubusercontent.com/4039331/80838702-e9920580-8bf9-11ea-9e42-7928fc4116bc.png)

