### PR TITLE
Use synchronous hints for replacing notifications

### DIFF
--- a/include/notification.h
+++ b/include/notification.h
@@ -42,6 +42,7 @@ struct mako_notification {
 	enum mako_notification_urgency urgency;
 	char *category;
 	char *desktop_entry;
+	char *tag;
 	int32_t progress;
 	struct mako_image_data *image_data;
 
@@ -89,6 +90,7 @@ char *format_hidden_text(char variable, bool *markup, void *data);
 char *format_notif_text(char variable, bool *markup, void *data);
 size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data);
 struct mako_notification *get_notification(struct mako_state *state, uint32_t id);
+struct mako_notification *get_tagged_notification(struct mako_state *state, const char *tag, const char *app_name);
 size_t format_notification(struct mako_notification *notif, const char *format,
 	char *buf);
 void notification_handle_button(struct mako_notification *notif, uint32_t button,

--- a/notification.c
+++ b/notification.c
@@ -44,6 +44,7 @@ void reset_notification(struct mako_notification *notif) {
 	free(notif->body);
 	free(notif->category);
 	free(notif->desktop_entry);
+	free(notif->tag);
 	if (notif->image_data != NULL) {
 		free(notif->image_data->data);
 		free(notif->image_data);
@@ -55,6 +56,7 @@ void reset_notification(struct mako_notification *notif) {
 	notif->body = strdup("");
 	notif->category = strdup("");
 	notif->desktop_entry = strdup("");
+	notif->tag = strdup("");
 
 	notif->image_data = NULL;
 
@@ -127,6 +129,17 @@ struct mako_notification *get_notification(struct mako_state *state,
 	struct mako_notification *notif;
 	wl_list_for_each(notif, &state->notifications, link) {
 		if (notif->id == id) {
+			return notif;
+		}
+	}
+	return NULL;
+}
+
+struct mako_notification *get_tagged_notification(struct mako_state *state,
+		const char *tag, const char *app_name) {
+	struct mako_notification *notif;
+	wl_list_for_each(notif, &state->notifications, link) {
+		if (strcmp(notif->tag, tag) == 0 && strcmp(notif->app_name, app_name) == 0) {
 			return notif;
 		}
 	}


### PR DESCRIPTION
`synchronous`, `private-synchronous`, `x-canonical-private-synchronous`, and
`x-dunst-stack-tag` are supported.
When a new notification with a tag is created the previous one with the
same tag is closed with `MAKO_NOTIFICATION_CLOSE_REPLACED`, and the new
notification is added to the list.

There's a behavior difference between replacing by ID and the new stack tag method. Replacing by ID will modify the notification in-place, whereas with the tag the new notification can be positioned differently as it's separately inserted into the list.
The synchronous tag is only identified once other hints have been processed and values have been set it isn't as easy to replace in-place.

Personally I prefer updated notifications being bumped up if they're replaced when they're supposed to be sorted by time, and I think replacing by ID should do the same. But if it's desirable to maintain the current behavior, here's some possible approaches:

1. Separate the notification ID generation from `create_notification`, so the ID can be set to the replaced ID or a new one as necessary
2. Find the tag hint before creating/replacing a notification. Not sure if the D-Bus API allows going through containers multiple times like this
3. Steal the existing notification's ID anyway (and optionally don't worry about the newly generated ID being lost)