### PR TITLE
Add regex support for summary criteria

### DIFF
--- a/criteria.c
+++ b/criteria.c
@@ -280,19 +280,19 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token) {
 		} else if (strcmp(key, "summary") == 0) {
 			criteria->summary = strdup(value);
 			if (criteria->spec.summary_pattern) {
-				fprintf(stderr, "Cannot set both summary and summary-pattern.");
+				fprintf(stderr, "Cannot set both summary and summary~ regex.\n");
 				return false;
 			}
 			criteria->spec.summary = true;
 			return true;
-		} else if (strcmp(key, "summary-pattern") == 0) {
+		} else if (strcmp(key, "summary~") == 0) {
 			if (regcomp(&criteria->summary_pattern, value,
 					REG_EXTENDED | REG_NOSUB)) {
-				fprintf(stderr, "Invalid summary-pattern regex '%s'\n", value);
+				fprintf(stderr, "Invalid summary~ regex '%s'\n", value);
 				return false;
 			}
 			if (criteria->spec.summary) {
-				fprintf(stderr, "Cannot set both summary and summary-pattern.");
+				fprintf(stderr, "Cannot set both summary and summary~ regex.\n");
 				return false;
 			}
 			criteria->spec.summary_pattern = true;

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -1,6 +1,7 @@
 #ifndef MAKO_CRITERIA_H
 #define MAKO_CRITERIA_H
 
+#include <regex.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <wayland-client.h>

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -28,7 +28,8 @@ struct mako_criteria {
 	enum mako_notification_urgency urgency;
 	char *category;
 	char *desktop_entry;
-	regex_t summary;
+	char *summary;
+	regex_t summary_pattern;
 	char *body;
 	int group_index;
 	bool grouped;  // Whether group_index is non-zero

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -27,7 +27,7 @@ struct mako_criteria {
 	enum mako_notification_urgency urgency;
 	char *category;
 	char *desktop_entry;
-	char *summary;
+	regex_t summary;
 	char *body;
 	int group_index;
 	bool grouped;  // Whether group_index is non-zero

--- a/include/types.h
+++ b/include/types.h
@@ -1,7 +1,6 @@
 #ifndef MAKO_TYPES_H
 #define MAKO_TYPES_H
 
-#include <regex.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <cairo.h>

--- a/include/types.h
+++ b/include/types.h
@@ -1,6 +1,7 @@
 #ifndef MAKO_TYPES_H
 #define MAKO_TYPES_H
 
+#include <regex.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <cairo.h>

--- a/include/types.h
+++ b/include/types.h
@@ -48,6 +48,7 @@ struct mako_criteria_spec {
 	bool category;
 	bool desktop_entry;
 	bool summary;
+	bool summary_pattern;
 	bool body;
 	bool group_index;
 	bool grouped;

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -243,8 +243,8 @@ The following fields are available in criteria:
 - _app-icon_ (string)
 - _summary_ (string)
 	- An exact match on the summary of the notification.
-	- This field conflicts with _summary-pattern_.
-- _summary-pattern_ (string)
+	- This field conflicts with _summary~_.
+- _summary~_ (string)
 	- A POSIX extended regular expression match on the summary of the
 	  notification.
 	- This field conflicts with _summary_.

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -242,7 +242,8 @@ The following fields are available in criteria:
 - _app-name_ (string)
 - _app-icon_ (string)
 - _summary_ (string)
-	- An exact match on the summary of the notification.
+	- A POSIX extended regular expression match on the summary of the
+	  notification.
 - _urgency_ (one of "low", "normal", "high")
 - _category_ (string)
 - _desktop-entry_ (string)

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -242,6 +242,8 @@ The following fields are available in criteria:
 - _app-name_ (string)
 - _app-icon_ (string)
 - _summary_ (string)
+	- An exact match on the summary of the notification.
+- _summary-pattern_ (string)
 	- A POSIX extended regular expression match on the summary of the
 	  notification.
 - _urgency_ (one of "low", "normal", "high")

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -243,9 +243,11 @@ The following fields are available in criteria:
 - _app-icon_ (string)
 - _summary_ (string)
 	- An exact match on the summary of the notification.
+	- This field conflicts with _summary-pattern_.
 - _summary-pattern_ (string)
 	- A POSIX extended regular expression match on the summary of the
 	  notification.
+	- This field conflicts with _summary_.
 - _urgency_ (one of "low", "normal", "high")
 - _category_ (string)
 - _desktop-entry_ (string)


### PR DESCRIPTION
This patch adds POSIX extended regular expression matching support for summary criteria.

I'm new to C and mako, so let me know anything that needs to be fixed / changed, but so far the following are parts I'd like to clarify:
```c
regexec(&criteria->summary, notif->summary, 0, NULL, 0)
```
This could error out, so should there be a check and output to stderr?

---
```diff
-	criteria->summary = strdup(notif->summary);
```
I'm not sure if this is okay or not. The `summary` for a notification's `mako_criteria` isn't currently accessed anywhere and the `mako_notification` already has the notification's summary, so I think it's alright. While it could be filled in by compiling the summary to regex, I don't think there's any point in doing so.
