### PR TITLE
Fix more memory issues

### DIFF
--- a/config.c
+++ b/config.c
@@ -756,18 +756,27 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 
 	optind = 1;
 	char *config_arg = NULL;
+	int opt_status = 0;
 	while (1) {
 		int option_index = -1;
 		int c = getopt_long(argc, argv, "hc:", long_options, &option_index);
 		if (c < 0) {
 			break;
 		} else if (c == 'h') {
-			return 1;
+			opt_status = 1;
+			break;
 		} else if (c == 'c') {
+			free(config_arg);
 			config_arg = strdup(optarg);
 		} else if (c != 0) {
-			return -1;
+			opt_status = -1;
+			break;
 		}
+	}
+
+	if (opt_status != 0) {
+		free(config_arg);
+		return opt_status;
 	}
 
 	int config_status = load_config_file(config, config_arg);

--- a/main.c
+++ b/main.c
@@ -97,8 +97,10 @@ int main(int argc, char *argv[]) {
 	int ret = reload_config(&state.config, argc, argv);
 
 	if (ret < 0) {
+		finish_config(&state.config);
 		return EXIT_FAILURE;
 	} else if (ret > 0) {
+		finish_config(&state.config);
 		printf("%s", usage);
 		return EXIT_SUCCESS;
 	}

--- a/types.c
+++ b/types.c
@@ -80,6 +80,7 @@ bool parse_mako_color(const char *string, struct mako_color *out) {
 
 		token = strtok_r(NULL, " \t", &saveptr);
 		if (token == NULL) {
+			free(components);
 			return false;
 		}
 	}
@@ -191,6 +192,7 @@ bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out) {
 		} else if (strcmp(token, "none") == 0) {
 			out->none = true;
 		} else {
+			free(components);
 			fprintf(stderr, "Unknown criteria field '%s'\n", token);
 			return false;
 		}


### PR DESCRIPTION
- acbbeaa: `state.config` needs to be freed before exiting
- f6c9f0d: `components` needs to be freed before returning
- acbbeaa: old values of `config_arg` should be freed in case the `-c` option is specified multiple times, and `config_arg` needs to be freed if returning before `load_config_arg()` is called
- f77b6e5: bit iffy about this one: scan-build thinks it's possible for a notification in the history list to remain in the list after being destroyed, which would cause a use-after-free and/or double-free. I'm quite sure that's impossible, but I rewrote the history pruning to use a for each loop instead and that's made the warning disappear