### PR TITLE
Improve robustness of config integer parsing

### DIFF
--- a/config.c
+++ b/config.c
@@ -485,9 +485,9 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	} else if (strcmp(name, "text-color") == 0) {
 		return spec->colors.text = parse_color(value, &style->colors.text);
 	} else if (strcmp(name, "width") == 0) {
-		return spec->width = parse_int(value, &style->width);
+		return spec->width = parse_int_ge(value, &style->width, 1);
 	} else if (strcmp(name, "height") == 0) {
-		return spec->height = parse_int(value, &style->height);
+		return spec->height = parse_int_ge(value, &style->height, 1);
 	} else if (strcmp(name, "margin") == 0) {
 		return spec->margin = parse_directional(value, &style->margin);
 	} else if (strcmp(name, "padding") == 0) {
@@ -498,7 +498,7 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		}
 		return spec->padding;
 	} else if (strcmp(name, "border-size") == 0) {
-		return spec->border_size = parse_int(value, &style->border_size);
+		return spec->border_size = parse_int_ge(value, &style->border_size, 0);
 	} else if (strcmp(name, "border-color") == 0) {
 		return spec->colors.border = parse_color(value, &style->colors.border);
 	} else if (strcmp(name, "progress-color") == 0) {
@@ -526,7 +526,7 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		return spec->icon_location = true;
 	} else if (strcmp(name, "max-icon-size") == 0) {
 		return spec->max_icon_size =
-			parse_int(value, &style->max_icon_size);
+			parse_int_ge(value, &style->max_icon_size, 1);
 	} else if (strcmp(name, "icon-path") == 0) {
 		free(style->icon_path);
 		return spec->icon_path = !!(style->icon_path = strdup(value));
@@ -539,7 +539,7 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		return spec->format = parse_format(value, &style->format);
 	} else if (strcmp(name, "default-timeout") == 0) {
 		return spec->default_timeout =
-			parse_int(value, &style->default_timeout);
+			parse_int_ge(value, &style->default_timeout, 0);
 	} else if (strcmp(name, "ignore-timeout") == 0) {
 		return spec->ignore_timeout =
 			parse_boolean(value, &style->ignore_timeout);
@@ -551,7 +551,7 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	} else if (strcmp(name, "history") == 0) {
 		return spec->history = parse_boolean(value, &style->history);
 	} else if (strcmp(name, "border-radius") == 0) {
-		spec->border_radius = parse_int(value, &style->border_radius);
+		spec->border_radius = parse_int_ge(value, &style->border_radius, 0);
 		if (spec->border_radius && spec->padding) {
 			style->padding.left = max(style->border_radius, style->padding.left);
 			style->padding.right = max(style->border_radius, style->padding.right);

--- a/include/types.h
+++ b/include/types.h
@@ -12,6 +12,7 @@ struct mako_color {
 
 bool parse_boolean(const char *string, bool *out);
 bool parse_int(const char *string, int *out);
+bool parse_int_ge(const char *string, int *out, int min);
 bool parse_color(const char *string, uint32_t *out);
 bool parse_mako_color(const char *string, struct mako_color *out);
 

--- a/types.c
+++ b/types.c
@@ -32,8 +32,24 @@ bool parse_boolean(const char *string, bool *out) {
 bool parse_int(const char *string, int *out) {
 	errno = 0;
 	char *end;
-	*out = (int)strtol(string, &end, 10);
-	return errno == 0 && end[0] == '\0';
+	int parsed;
+	parsed = (int)strtol(string, &end, 10);
+	if (errno == 0 && end[0] == '\0') {
+		*out = parsed;
+		return true;
+	} else {
+		return false;
+	}
+}
+
+bool parse_int_ge(const char *string, int *out, int min) {
+	int parsed;
+	if (parse_int(string, &parsed) && parsed >= min) {
+		*out = parsed;
+		return true;
+	} else {
+		return false;
+	}
 }
 
 bool parse_color(const char *string, uint32_t *out) {


### PR DESCRIPTION
Instead of parsing directly into the target config attribute, use a temporary variable. This avoids cases where we could report parsing as failed, like for '57asdf', but would have already set the value to 57. Also validate that integers are in range, for options which have one.

Fixes #130, and a bunch that haven't been reported yet. :)