### PR TITLE
Accept id args in makoctl for menu and dismiss

### DIFF
--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -70,7 +70,8 @@ static int handle_dismiss_notification(sd_bus_message *msg, void *data,
 	struct mako_state *state = data;
 
 	uint32_t id = 0;
-	int ret = sd_bus_message_read(msg, "u", &id);
+	uint32_t dismiss_group = 0;
+	int ret = sd_bus_message_read(msg, "ub", &id, &dismiss_group);
 	if (ret < 0) {
 		return ret;
 	}
@@ -86,7 +87,11 @@ static int handle_dismiss_notification(sd_bus_message *msg, void *data,
 	struct mako_notification *notif;
 	wl_list_for_each(notif, &state->notifications, link) {
 		if (notif->id == id) {
-			close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+			if (dismiss_group) {
+				close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+			} else {
+				close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+			}
 			set_dirty(notif->surface);
 			break;
 		}
@@ -351,7 +356,7 @@ static const sd_bus_vtable service_vtable[] = {
 	SD_BUS_METHOD("DismissAllNotifications", "", "", handle_dismiss_all_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("DismissGroupNotifications", "", "", handle_dismiss_group_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("DismissLastNotification", "", "", handle_dismiss_last_notification, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("DismissNotification", "u", "", handle_dismiss_notification, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("DismissNotification", "ub", "", handle_dismiss_notification, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("InvokeAction", "us", "", handle_invoke_action, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("RestoreNotification", "", "", handle_restore_action, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("ListNotifications", "", "aa{sv}", handle_list_notifications, SD_BUS_VTABLE_UNPRIVILEGED),

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -70,7 +70,7 @@ static int handle_dismiss_notification(sd_bus_message *msg, void *data,
 	struct mako_state *state = data;
 
 	uint32_t id = 0;
-	uint32_t dismiss_group = 0;
+	int dismiss_group = 0;
 	int ret = sd_bus_message_read(msg, "ub", &id, &dismiss_group);
 	if (ret < 0) {
 		return ret;
@@ -78,10 +78,6 @@ static int handle_dismiss_notification(sd_bus_message *msg, void *data,
 
 	if (id == 0) {
 		id = state->last_id;
-	}
-
-	if (wl_list_empty(&state->notifications)) {
-		goto done;
 	}
 
 	struct mako_notification *notif;
@@ -97,7 +93,6 @@ static int handle_dismiss_notification(sd_bus_message *msg, void *data,
 		}
 	}
 
-done:
 	return sd_bus_reply_method_return(msg, "");
 }
 

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -65,6 +65,37 @@ done:
 	return sd_bus_reply_method_return(msg, "");
 }
 
+static int handle_dismiss_notification(sd_bus_message *msg, void *data,
+		sd_bus_error *ret_error) {
+	struct mako_state *state = data;
+
+	uint32_t id = 0;
+	int ret = sd_bus_message_read(msg, "u", &id);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (id == 0) {
+		id = state->last_id;
+	}
+
+	if (wl_list_empty(&state->notifications)) {
+		goto done;
+	}
+
+	struct mako_notification *notif;
+	wl_list_for_each(notif, &state->notifications, link) {
+		if (notif->id == id) {
+			close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+			set_dirty(notif->surface);
+			break;
+		}
+	}
+
+done:
+	return sd_bus_reply_method_return(msg, "");
+}
+
 static int handle_invoke_action(sd_bus_message *msg, void *data,
 		sd_bus_error *ret_error) {
 	struct mako_state *state = data;
@@ -320,6 +351,7 @@ static const sd_bus_vtable service_vtable[] = {
 	SD_BUS_METHOD("DismissAllNotifications", "", "", handle_dismiss_all_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("DismissGroupNotifications", "", "", handle_dismiss_group_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("DismissLastNotification", "", "", handle_dismiss_last_notification, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("DismissNotification", "u", "", handle_dismiss_notification, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("InvokeAction", "us", "", handle_invoke_action, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("RestoreNotification", "", "", handle_restore_action, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("ListNotifications", "", "aa{sv}", handle_list_notifications, SD_BUS_VTABLE_UNPRIVILEGED),

--- a/makoctl
+++ b/makoctl
@@ -4,7 +4,9 @@ usage() {
 	echo "Usage: makoctl <command> [options...]"
 	echo ""
 	echo "Commands:"
-	echo "  dismiss                        Dismiss the last notification"
+	echo "  dismiss [id]                   Dismiss the notification with the"
+	echo "                                 given id, or the last notification"
+	echo "                                 if none is given"
 	echo "          [-a|--all]             Dismiss all notifications"
 	echo "          [-g|--group]           Dismiss all the notifications"
 	echo "                                 in the last notification's group"
@@ -35,20 +37,21 @@ fi
 
 case "$1" in
 "dismiss")
-	[ $# -lt 2 ] && action="" || action="$2"
-	case "$action" in
+	[ $# -lt 2 ] && arg="0" || arg=$2
+	case "$arg" in
 	"-a"|"--all")
 		call DismissAllNotifications
 		;;
 	"-g"|"--group")
 		call DismissGroupNotifications
 		;;
-	"")
-		call DismissLastNotification
-		;;
 	*)
-		echo "makoctl: unrecognized option '$2'"
-		exit 1
+		re='^[0-9]+$'
+		if ! [[ $arg =~ $re ]] ; then
+			echo "makoctl: Unrecognized ID: '$arg'"
+			exit 1
+		fi
+		call DismissNotification "u" "$arg"
 		;;
 	esac
 	;;

--- a/makoctl
+++ b/makoctl
@@ -4,7 +4,7 @@ usage() {
 	echo "Usage: makoctl <command> [options...]"
 	echo ""
 	echo "Commands:"
-	echo "  dismiss [id]                   Dismiss the notification with the"
+	echo "  dismiss [-n id]                Dismiss the notification with the"
 	echo "                                 given id, or the last notification"
 	echo "                                 if none is given"
 	echo "          [-a|--all]             Dismiss all notifications"
@@ -37,23 +37,39 @@ fi
 
 case "$1" in
 "dismiss")
-	[ $# -lt 2 ] && arg="0" || arg=$2
-	case "$arg" in
-	"-a"|"--all")
-		call DismissAllNotifications
-		;;
-	"-g"|"--group")
-		call DismissGroupNotifications
-		;;
-	*)
-		re='^[0-9]+$'
-		if ! [[ $arg =~ $re ]] ; then
-			echo "makoctl: Unrecognized ID: '$arg'"
+	all=0
+	group=0
+	id=0
+	while [ $# -gt 1 ]; do
+		case "$2" in
+		"-a"|"--all")
+			all=1
+			;;
+		"-g"|"--group")
+			group=1
+			;;
+		"-n")
+			if [ $# -lt 3 ]; then
+				echo >&2 "$0: Expected <id> after '-n'"
+				exit 1
+			fi
+			id=$3
+			shift
+			;;
+		*)
+			echo >&2 "$0: Unrecognized option: $2"
 			exit 1
-		fi
-		call DismissNotification "u" "$arg"
-		;;
-	esac
+			;;
+		esac
+		shift
+	done
+
+	if [ $all -eq 1 ]; then
+		echo "all!!"
+		call DismissAllNotifications
+	else
+		call DismissNotification "ub" "$id" "$group"
+	fi
 	;;
 "invoke")
 	id=0
@@ -85,7 +101,6 @@ case "$1" in
 	else
 		actions="$(call ListNotifications | jq -re '.data[0][0].actions.data')"
 		id="0"
-		echo $id
 	fi
 	if [ "$(jq -rn "$actions | length")" -eq "0" ]; then
 		echo >&2 "$0: No actions found"

--- a/makoctl
+++ b/makoctl
@@ -65,7 +65,6 @@ case "$1" in
 	done
 
 	if [ $all -eq 1 ]; then
-		echo "all!!"
 		call DismissAllNotifications
 	else
 		call DismissNotification "ub" "$id" "$group"
@@ -95,8 +94,8 @@ case "$1" in
 		exit 1
 	fi
 	if [ $# -gt 1 ] && [ "$1" = "-n" ]; then
-		id=$2
-		actions="$(call ListNotifications | id=$id jq --arg id $id -re '.data[0][] | select(.id.data==($id | tonumber)) | .actions.data')"
+		id="$2"
+		actions="$(call ListNotifications | jq --arg id "$id" -re '.data[0][] | select(.id.data==($id | tonumber)) | .actions.data')"
 		shift 2
 	else
 		actions="$(call ListNotifications | jq -re '.data[0][0].actions.data')"

--- a/makoctl
+++ b/makoctl
@@ -4,21 +4,23 @@ usage() {
 	echo "Usage: makoctl <command> [options...]"
 	echo ""
 	echo "Commands:"
-	echo "  dismiss                  Dismiss the last notification"
-	echo "          [-a|--all]       Dismiss all notifications"
-	echo "          [-g|--group]     Dismiss all the notifications"
-	echo "                           in the last notification's group"
-	echo "  restore                  Restore the most recently expired"
-	echo "                           notification from the history buffer"
-	echo "  invoke [-n id] [action]  Invoke an action on the notification"
-	echo "                           with the given id, or the last"
-	echo "                           notification if none is given"
-	echo "  menu [prog] [arg ...]    Use [prog] [args ...] to select one"
-	echo "                           notification action to be invoked"
-	echo "  list                     List notifications"
-	echo "  reload                   Reload the configuration file"
-	echo "  set <key>=<value>        Set a global configuration option"
-	echo "  help                     Show this help"
+	echo "  dismiss                        Dismiss the last notification"
+	echo "          [-a|--all]             Dismiss all notifications"
+	echo "          [-g|--group]           Dismiss all the notifications"
+	echo "                                 in the last notification's group"
+	echo "  restore                        Restore the most recently expired"
+	echo "                                 notification from the history buffer"
+	echo "  invoke [-n id] [action]        Invoke an action on the notification"
+	echo "                                 with the given id, or the last"
+	echo "                                 notification if none is given"
+	echo "  menu [-n id] [prog] [arg ...]  Use [prog] [args ...] to select one"
+	echo "                                 action to be invoked on the notification"
+	echo "                                 with the given id, or the last"
+	echo "                                 notification if none is given"
+	echo "  list                           List notifications"
+	echo "  reload                         Reload the configuration file"
+	echo "  set <key>=<value>              Set a global configuration option"
+	echo "  help                           Show this help"
 }
 
 call() {
@@ -73,18 +75,27 @@ case "$1" in
 		echo >&2 "$0: jq is required to use 'menu'"
 		exit 1
 	fi
-	if array="$(call ListNotifications | jq -re '.data[0][0].actions.data | if length > 0 then . else false end')"; then
-		sel="$(jq -rn "$array|values[]" | "$@")"
-		sel="$(jq -rn --arg sel "$sel" "$array|to_entries[]|select(.value == \$sel).key")"
-		if [ -z "$sel" ]; then
-			echo >&2 "$0: No action selected"
-			exit 1
-		else
-			call InvokeAction "us" 0 "$sel"
-		fi
+	if [ $# -gt 1 ] && [ "$1" = "-n" ]; then
+		id=$2
+		actions="$(call ListNotifications | id=$id jq --arg id $id -re '.data[0][] | select(.id.data==($id | tonumber)) | .actions.data')"
+		shift 2
 	else
+		actions="$(call ListNotifications | jq -re '.data[0][0].actions.data')"
+		id="0"
+		echo $id
+	fi
+	if [ "$(jq -rn "$actions | length")" -eq "0" ]; then
 		echo >&2 "$0: No actions found"
 		exit 1
+	fi
+
+	sel="$(jq -rn "$actions|values[]" | "$@")"
+	sel="$(jq -rn --arg sel "$sel" "$actions|to_entries[]|select(.value == \$sel).key")"
+	if [ -z "$sel" ]; then
+		echo >&2 "$0: No action selected"
+		exit 1
+	else
+		call InvokeAction "us" "$id" "$sel"
 	fi
 	;;
 "list")


### PR DESCRIPTION
Follow-up from the short discussion in #283.

There are things around `dismiss` that are not ideal, but I didn't want to introduce breaking changes without first discussing it. Ideally, we would do the following:
1. `makoctl dismiss` would look like `makoctl dismiss [-n id] [-g]`, and `makoctl dismiss-all` would be a separate action.
2. `DismissLastNotification` dbus action is redundant, but can remain around for compatibility