### PR TITLE
Add dockerfiles for building and packaging on debian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ Mkfile.old
 dkms.conf
 
 build/
+*.deb

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,8 @@
+FROM debian:buster
+
+RUN apt update \
+  && apt install -y gcc meson libpango1.0-dev libcairo2-dev libsystemd-dev libgdk-pixbuf2.0-dev libwayland-dev wayland-protocols libelogind-dev scdoc
+
+WORKDIR /mako
+
+CMD meson build && ninja -C build

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,16 @@
+FROM debian:buster
+
+WORKDIR /root
+
+RUN mkdir -p mako_1/usr/local/bin \
+  && mkdir -p mako_1/DEBIAN \
+  && echo 'Package: mako\n\
+Version: 1\n\
+Section: base\n\
+Priority: optional\n\
+Architecture: amd64\n\
+Depends:\n\
+Maintainer: Your Name <you@email.com>\n\
+Description: mako' > mako_1/DEBIAN/control
+
+CMD dpkg-deb --build mako_1 && mv mako_1.deb /output

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ For control of mako during runtime, `makoctl` can be used; see `man makoctl`
 
 Install dependencies:
 
+* gcc
 * meson (build-time dependency)
 * wayland
 * pango
@@ -58,6 +59,43 @@ build/mako
 <p align="center">
   <img src="https://sr.ht/frOL.jpg" alt="mako">
 </p>
+
+### With docker 🐋
+
+#### Compile the code using `mako-builder` 🚜
+
+Build the `builder`
+
+```sh
+docker build --rm -t mako-builder -f Dockerfile.builder .
+```
+
+Use the builder to compile the code
+
+```sh
+docker run --rm -v $(pwd):/root mako-builder
+```
+
+#### Create a debian package 📦
+
+Build the debian packager
+
+```sh
+docker build --rm -t mako-debian -f Dockerfile.debian
+```
+
+Package the package
+
+```sh
+docker run --rm -v $(pwd)/build/mako:/root/mako_1/usr/local/bin/mako -v
+$(pwd):/output mako-debian
+```
+
+Now it is ready to be installed! Install with
+
+```sh
+dpkg -i mako_1.deb
+```
 
 ## I have a question!
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker build --rm -t mako-builder -f Dockerfile.builder .
 Use the builder to compile the code
 
 ```sh
-docker run --rm -v $(pwd):/root mako-builder
+docker run --rm -v $(pwd):/mako mako-builder
 ```
 
 #### Create a debian package 📦
@@ -81,14 +81,13 @@ docker run --rm -v $(pwd):/root mako-builder
 Build the debian packager
 
 ```sh
-docker build --rm -t mako-debian -f Dockerfile.debian
+docker build --rm -t mako-debian -f Dockerfile.debian .
 ```
 
 Package the package
 
 ```sh
-docker run --rm -v $(pwd)/build/mako:/root/mako_1/usr/local/bin/mako -v
-$(pwd):/output mako-debian
+docker run --rm -v $(pwd)/build/mako:/root/mako_1/usr/local/bin/mako -v $(pwd):/output mako-debian
 ```
 
 Now it is ready to be installed! Install with


### PR DESCRIPTION
Added crude dockerfiles for
1. Compiling mako from source
1. Creating a crude debian package (not for distributing)

Added instructions for using the dockerfiles.

I hope they can be helpful with ci too.