### PR TITLE
systemd: improve ExecCondition to support absence of $WAYLAND_DISPLAY

### DIFF
--- a/contrib/systemd/mako.service.in
+++ b/contrib/systemd/mako.service.in
@@ -7,7 +7,7 @@ After=graphical-session.target
 [Service]
 Type=dbus
 BusName=org.freedesktop.Notifications
-ExecCondition=/bin/sh -c '[ -n "$WAYLAND_DISPLAY" ]'
+ExecCondition=/bin/sh -c '[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]'
 ExecStart=@bindir@/mako
 ExecReload=@bindir@/makoctl reload
 


### PR DESCRIPTION
Following up from #240, the current `ExecCondition` relies on the environment variable `WAYLAND_DISPLAY` to be set, but this in turn relies on the fact that... sway somehow sets it for systemd to see (only when sway is started by systemd?).

Regardless of the specifics, referring to the [infamous thread](https://github.com/swaywm/sway/issues/5160) about systemd service for sway, there are examples when users aren't using `environment.d` (I'm one of them). But even though I don't run sway via systemd, I thought I could benefit from mako being auto-started via DBUS-activation of this systemd unit.

This PR changes the `ExecCondition` so that even if systemd doesn't see my `WAYLAND_DISPLAY` variable, it can still detect the presence of the wayland session.

Thoughts?

cc @WhyNotHugo 