### PR TITLE
Update AppArmor profile

### DIFF
--- a/contrib/apparmor/fr.emersion.Mako
+++ b/contrib/apparmor/fr.emersion.Mako
@@ -6,7 +6,7 @@ profile fr.emersion.Mako /usr/bin/mako {
   #include <abstractions/freedesktop.org>
   #include <abstractions/wayland>
 
-  #include <abstractions/dbus-strict>
+  #include <abstractions/dbus-session-strict>
   dbus bind
        bus=session
        name=org.freedesktop.Notifications,


### PR DESCRIPTION
Not sure why it actually works with `dbus-strict` but in principle it should be `dbus-session-strict` since dbus-strict is for system bus, not a session one.