### PR TITLE
Add surface criteria and make max-visible and hidden actually work per surface

### DIFF
--- a/config.c
+++ b/config.c
@@ -733,7 +733,7 @@ int load_config_file(struct mako_config *config, char *config_arg) {
 
 	// Validate the final criteria section since there was no opening bracket
 	// after it to do this in the loop.
-	if (criteria != NULL && !validate_criteria(criteria)) {
+	if (ret != -1 && criteria != NULL && !validate_criteria(criteria)) {
 		fprintf(stderr, "Invalid configuration in criteria: [%s]\n",
 				criteria->raw_string);
 		ret = -1;

--- a/config.c
+++ b/config.c
@@ -691,6 +691,15 @@ int load_config_file(struct mako_config *config, char *config_arg) {
 		}
 
 		if (line[0] == '[' && line[strlen(line) - 1] == ']') {
+			// Since we hit the end of the previous criteria section, validate
+			// that it doesn't break any rules before moving on.
+			if (criteria != NULL && !validate_criteria(criteria)) {
+				fprintf(stderr, "Invalid configuration in criteria: [%s]\n",
+						criteria->raw_string);
+				ret = -1;
+				break;
+			}
+
 			free(section);
 			section = strndup(line + 1, strlen(line) - 2);
 			if (strcmp(section, "hidden") == 0) {
@@ -742,6 +751,14 @@ int load_config_file(struct mako_config *config, char *config_arg) {
 			ret = -1;
 			break;
 		}
+	}
+
+	// Validate the final criteria section since there was no opening bracket
+	// after it to do this in the loop.
+	if (criteria != NULL && !validate_criteria(criteria)) {
+		fprintf(stderr, "Invalid configuration in criteria: [%s]\n",
+				criteria->raw_string);
+		ret = -1;
 	}
 
 	free(section);

--- a/config.c
+++ b/config.c
@@ -579,29 +579,7 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		style->spec.layer = true;
 		return true;
 	} else if (strcmp(name, "anchor") == 0) {
-		if (strcmp(value, "top-right") == 0) {
-			style->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
-				ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
-		} else if (strcmp(value, "top-center") == 0) {
-			style->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
-		} else if (strcmp(value, "top-left") == 0) {
-			style->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
-				ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
-		} else if (strcmp(value, "bottom-right") == 0) {
-			style->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
-				ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
-		} else if (strcmp(value, "bottom-center") == 0) {
-			style->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
-		} else if (strcmp(value, "bottom-left") == 0) {
-			style->anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
-				ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
-		} else if (strcmp(value, "center") == 0) {
-			style->anchor = 0;
-		} else {
-			return false;
-		}
-		style->spec.anchor = true;
-		return true;
+		return spec->anchor = parse_anchor(value, &style->anchor);
 	}
 
 	return false;

--- a/config.c
+++ b/config.c
@@ -44,11 +44,16 @@ void init_default_config(struct mako_config *config) {
 	new_criteria->style.spec.invisible = true;
 	new_criteria->raw_string = strdup("(default group-index=0)");
 
-	init_empty_style(&config->superstyle);
+	// Define the default format for the hidden placeholder notification.
+	new_criteria = create_criteria(config);
+	init_empty_style(&new_criteria->style);
+	new_criteria->hidden = true;
+	new_criteria->spec.hidden = true;
+	new_criteria->style.format = strdup("(%h more)");
+	new_criteria->style.spec.format = true;
+	new_criteria->raw_string = strdup("(default hidden)");
 
-	init_empty_style(&config->hidden_style);
-	config->hidden_style.format = strdup("(%h more)");
-	config->hidden_style.spec.format = true;
+	init_empty_style(&config->superstyle);
 
 	config->max_history = 5;
 	config->sort_criteria = MAKO_SORT_CRITERIA_TIME;
@@ -67,7 +72,6 @@ void finish_config(struct mako_config *config) {
 	}
 
 	finish_style(&config->superstyle);
-	finish_style(&config->hidden_style);
 }
 
 void init_default_style(struct mako_style *style) {
@@ -680,11 +684,6 @@ int load_config_file(struct mako_config *config, char *config_arg) {
 
 			free(section);
 			section = strndup(line + 1, strlen(line) - 2);
-			if (strcmp(section, "hidden") == 0) {
-				// Skip making a criteria for the hidden section.
-				criteria = NULL;
-				continue;
-			}
 			criteria = create_criteria(config);
 			if (!parse_criteria(section, criteria)) {
 				fprintf(stderr, "[%s:%d] Invalid criteria definition\n", base,
@@ -705,18 +704,7 @@ int load_config_file(struct mako_config *config, char *config_arg) {
 		bool valid_option = false;
 		eq[0] = '\0';
 
-		struct mako_style *target_style;
-		if (section != NULL && strcmp(section, "hidden") == 0) {
-			// The hidden criteria is a lie, we store the associated style
-			// directly on the config because there's no "real" notification
-			// object to match against it later.
-			target_style = &config->hidden_style;
-		} else {
-			assert(criteria != NULL);
-			target_style = &criteria->style;
-		}
-
-		valid_option = apply_style_option(target_style, line, eq + 1);
+		valid_option = apply_style_option(&criteria->style, line, eq + 1);
 
 		if (!valid_option && section == NULL) {
 			valid_option = apply_config_option(config, line, eq + 1);

--- a/criteria.c
+++ b/criteria.c
@@ -493,6 +493,18 @@ bool validate_criteria(struct mako_criteria *criteria) {
 		}
 	}
 
+	struct mako_criteria_spec copy = {0};
+	memcpy(&copy, &criteria->spec, sizeof(struct mako_criteria_spec));
+	copy.output = false;
+	copy.anchor = false;
+	bool any_but_surface = mako_criteria_spec_any(&copy);
+
+	if (criteria->style.max_visible && any_but_surface) {
+		fprintf(stderr, "Setting `max_visible` is allowed only for `output` "
+				"and/or `anchor`\n");
+		return false;
+	}
+
 	if (criteria->spec.summary && criteria->spec.summary_pattern) {
 		fprintf(stderr, "Cannot set both `summary` and `summary~`\n");
 		return false;

--- a/criteria.c
+++ b/criteria.c
@@ -451,9 +451,7 @@ struct mako_criteria *create_criteria_from_notification(
 
 
 // To keep the behavior of criteria predictable, there are a few rules that we
-// have to impose on what can be modified depending on what was matched:
-// - Criteria matching grouped notifications are not allowed to change the
-//   anchor, output, or group-by, as this would invalidate the grouping.
+// have to impose on what can be modified depending on what was matched.
 bool validate_criteria(struct mako_criteria *criteria) {
 	if (criteria->spec.grouped || criteria->spec.group_index) {
 		static const char *message =

--- a/criteria.c
+++ b/criteria.c
@@ -487,22 +487,25 @@ struct mako_criteria *create_criteria_from_notification(
 // To keep the behavior of criteria predictable, there are a few rules that we
 // have to impose on what can be modified depending on what was matched.
 bool validate_criteria(struct mako_criteria *criteria) {
+	char * invalid_option = NULL;
+
 	if (criteria->spec.grouped ||
 			criteria->spec.group_index ||
 			criteria->spec.output ||
 			criteria->spec.anchor) {
-		static const char *message =
-			"Setting `%s` is not allowed when matching `grouped`, "
-			"`group-index`, `output`, or `anchor`\n";
-
 		if (criteria->style.spec.anchor) {
-			fprintf(stderr, message, "anchor");
-			return false;
+			invalid_option = "anchor";
 		} else if (criteria->style.spec.output) {
-			fprintf(stderr, message, "output");
-			return false;
+			invalid_option = "output";
 		} else if (criteria->style.spec.group_criteria_spec) {
-			fprintf(stderr, message, "group-by");
+			invalid_option = "group-by";
+		}
+
+		if (invalid_option) {
+			fprintf(stderr,
+					"Setting `%s` is not allowed when matching `grouped`, "
+					"`group-index`, `output`, or `anchor`\n",
+					invalid_option);
 			return false;
 		}
 	}
@@ -539,19 +542,20 @@ bool validate_criteria(struct mako_criteria *criteria) {
 
 	if (criteria->style.spec.group_criteria_spec) {
 		struct mako_criteria_spec *spec = &criteria->style.group_criteria_spec;
-		static const char *message = "`%s` cannot be used in `group-by`\n";
 
 		if (spec->group_index) {
-			fprintf(stderr, message, "group-index");
-			return false;
+			invalid_option = "group-index";
 		} else if (spec->grouped) {
-			fprintf(stderr, message, "grouped");
-			return false;
+			invalid_option = "grouped";
 		} else if (spec->anchor) {
-			fprintf(stderr, message, "anchor");
-			return false;
+			invalid_option = "anchor";
 		} else if (spec->output) {
-			fprintf(stderr, message, "output");
+			invalid_option = "output";
+		}
+
+		if (invalid_option) {
+			fprintf(stderr, "`%s` cannot be used in `group-by`\n",
+					invalid_option);
 			return false;
 		}
 	}

--- a/criteria.c
+++ b/criteria.c
@@ -427,7 +427,7 @@ ssize_t apply_each_criteria(struct wl_list *criteria_list,
 
 	if (!notif->surface) {
 		notif->surface = create_surface(notif->state, notif->style.output,
-			notif->style.layer, notif->style.anchor, notif->style.max_visible);
+			notif->style.layer, notif->style.anchor);
 	}
 
 	return match_count;

--- a/criteria.c
+++ b/criteria.c
@@ -321,20 +321,12 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token) {
 			return true;
 		} else if (strcmp(key, "body") == 0) {
 			criteria->body = strdup(value);
-			if (criteria->spec.body_pattern) {
-				fprintf(stderr, "Cannot set both body and body~ regex.\n");
-				return false;
-			}
 			criteria->spec.body = true;
 			return true;
 		} else if (strcmp(key, "body~") == 0) {
 			if (regcomp(&criteria->body_pattern, value,
 					REG_EXTENDED | REG_NOSUB)) {
 				fprintf(stderr, "Invalid body~ regex '%s'\n", value);
-				return false;
-			}
-			if (criteria->spec.body) {
-				fprintf(stderr, "Cannot set both body and body~ regex.\n");
 				return false;
 			}
 			criteria->spec.body_pattern = true;
@@ -507,6 +499,11 @@ bool validate_criteria(struct mako_criteria *criteria) {
 
 	if (criteria->spec.summary && criteria->spec.summary_pattern) {
 		fprintf(stderr, "Cannot set both `summary` and `summary~`\n");
+		return false;
+	}
+
+	if (criteria->spec.body && criteria->spec.body_pattern) {
+		fprintf(stderr, "Cannot set both `body` and `body~`\n");
 		return false;
 	}
 

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -113,14 +113,14 @@ static int handle_notify(sd_bus_message *msg, void *data,
 		return -1;
 	}
 
+	free(notif->app_name);
+	free(notif->app_icon);
+	free(notif->summary);
+	free(notif->body);
 	notif->app_name = strdup(app_name);
 	notif->app_icon = strdup(app_icon);
 	notif->summary = strdup(summary);
 	notif->body = strdup(body);
-
-	// These fields may not be filled, so make sure they're valid strings.
-	notif->category = strdup("");
-	notif->desktop_entry = strdup("");
 
 	ret = sd_bus_message_enter_container(msg, 'a', "s");
 	if (ret < 0) {

--- a/include/config.h
+++ b/include/config.h
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include <wayland-client.h>
 #include "types.h"
-#include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
 enum mako_binding {
 	MAKO_BINDING_NONE,

--- a/include/config.h
+++ b/include/config.h
@@ -88,7 +88,6 @@ struct mako_config {
 	uint32_t sort_asc;
 	int32_t max_history;
 
-	struct mako_style hidden_style;
 	struct mako_style superstyle;
 
 	struct {

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -51,4 +51,6 @@ ssize_t apply_each_criteria(struct wl_list *criteria_list,
 struct mako_criteria *create_criteria_from_notification(
 		struct mako_notification *notif, struct mako_criteria_spec *spec);
 
+bool validate_criteria(struct mako_criteria *criteria);
+
 #endif

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -32,8 +32,12 @@ struct mako_criteria {
 	regex_t summary_pattern;
 	char *body;
 	regex_t body_pattern;
+
+	// Second-pass matches:
 	int group_index;
 	bool grouped;  // Whether group_index is non-zero
+	char *output;
+	uint32_t anchor;
 };
 
 struct mako_criteria *create_criteria(struct mako_config *config);

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -38,6 +38,7 @@ struct mako_criteria {
 	bool grouped;  // Whether group_index is non-zero
 	char *output;
 	uint32_t anchor;
+	bool hidden;
 };
 
 struct mako_criteria *create_criteria(struct mako_config *config);

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -55,6 +55,8 @@ ssize_t apply_each_criteria(struct wl_list *criteria_list,
 struct mako_criteria *create_criteria_from_notification(
 		struct mako_notification *notif, struct mako_criteria_spec *spec);
 
+bool mako_criteria_spec_any(struct mako_criteria_spec *spec);
+
 bool validate_criteria(struct mako_criteria *criteria);
 
 #endif

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -55,8 +55,6 @@ ssize_t apply_each_criteria(struct wl_list *criteria_list,
 struct mako_criteria *create_criteria_from_notification(
 		struct mako_notification *notif, struct mako_criteria_spec *spec);
 
-bool mako_criteria_spec_any(struct mako_criteria_spec *spec);
-
 bool validate_criteria(struct mako_criteria *criteria);
 
 #endif

--- a/include/mako.h
+++ b/include/mako.h
@@ -36,7 +36,6 @@ struct mako_surface {
 	char *configured_output;
 	enum zwlr_layer_shell_v1_layer layer;
 	uint32_t anchor;
-	int32_t max_visible;
 
 	int32_t width, height;
 	struct pool_buffer buffers[2];

--- a/include/notification.h
+++ b/include/notification.h
@@ -30,6 +30,7 @@ struct mako_notification {
 	uint32_t id;
 	int group_index;
 	int group_count;
+	bool hidden;
 
 	char *app_name;
 	char *app_icon;

--- a/include/surface.h
+++ b/include/surface.h
@@ -8,6 +8,5 @@ struct mako_surface;
 
 void destroy_surface(struct mako_surface *surface);
 struct mako_surface *create_surface(struct mako_state *state, const char *output,
-		enum zwlr_layer_shell_v1_layer layer, uint32_t anchor,
-		int32_t max_visible);
+		enum zwlr_layer_shell_v1_layer layer, uint32_t anchor);
 #endif

--- a/include/types.h
+++ b/include/types.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <cairo.h>
+#include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
 struct mako_color {
 	uint32_t value;
@@ -15,6 +16,7 @@ bool parse_int(const char *string, int *out);
 bool parse_int_ge(const char *string, int *out, int min);
 bool parse_color(const char *string, uint32_t *out);
 bool parse_mako_color(const char *string, struct mako_color *out);
+bool parse_anchor(const char *string, uint32_t *out);
 
 enum mako_notification_urgency {
 	MAKO_NOTIFICATION_URGENCY_LOW = 0,
@@ -52,10 +54,15 @@ struct mako_criteria_spec {
 	bool summary_pattern;
 	bool body;
 	bool body_pattern;
-	bool group_index;
-	bool grouped;
 
 	bool none; // Special criteria that never matches, used for grouping
+
+	// Fields that can only be matched after grouping, and thus can't be
+	// used to group.
+	bool group_index;
+	bool grouped;
+	bool output;
+	bool anchor;
 };
 
 bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out);

--- a/include/types.h
+++ b/include/types.h
@@ -63,6 +63,7 @@ struct mako_criteria_spec {
 	bool grouped;
 	bool output;
 	bool anchor;
+	bool hidden;
 };
 
 bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out);

--- a/include/types.h
+++ b/include/types.h
@@ -66,6 +66,7 @@ struct mako_criteria_spec {
 };
 
 bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out);
+bool mako_criteria_spec_any(const struct mako_criteria_spec *spec);
 
 // List of specifier characters that can appear in a format string.
 extern const char VALID_FORMAT_SPECIFIERS[];

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -300,6 +300,14 @@ There are three criteria always present at the front of the list:
 These options can be overridden by simply defining the criteria yourself and
 overriding them.
 
+There are some rules restricting what can be configured depending on what is
+being matched by a given criteria:
+
+- Criteria matching _grouped_ or _group-index_ are not allowed to change the
+  _anchor_, _output_, or _group-by_, as this would invalidate the grouping.
+  Grouping is only performed once rather than recursively, to avoid the
+  potential for infinite loops.
+
 # CRITERIA-ONLY STYLE OPTIONS
 
 Some style options are not useful in the global context and therefore have no

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -263,6 +263,10 @@ The following fields are available in criteria:
 - _desktop-entry_ (string)
 - _actionable_ (boolean)
 - _expiring_ (boolean)
+
+The following fields are also available to match on a second pass based on
+where previous style options decided to place each notification:
+
 - _grouped_ (boolean)
 	- Whether the notification is grouped with any others (its group-index is
 	  not -1).
@@ -271,6 +275,15 @@ The following fields are available in criteria:
 - _hidden_ (boolean)
 	- _hidden_ is special, it defines the style for the placeholder shown when
 	  the number of notifications or groups exceeds _max-visible_.
+- _output_ (string)
+    - Which output the notification was sorted onto. See the output style
+	  option for possible values.
+- _anchor_ (string)
+	- Which position on the output the notification was assigned to. See the
+      anchor style option for possible values.
+
+There are only two passes performed on each notification, so the second-pass
+critera are not allowed to reposition the notification.
 
 If a field's value contains special characters, they may be escaped with a
 backslash, or quoted:

--- a/notification.c
+++ b/notification.c
@@ -469,20 +469,6 @@ int group_notifications(struct mako_state *state, struct mako_criteria *criteria
 	// anymore.
 	wl_list_for_each(notif, &matches, link) {
 		notif->group_count = count;
-
-		int rematch_count = apply_each_criteria(&state->config.criteria, notif);
-		if (rematch_count == -1) {
-			// We encountered an allocation failure or similar while applying
-			// criteria. The notification may be partially matched, but the
-			// worst case is that it has an empty style, so bail.
-			fprintf(stderr, "Failed to apply criteria\n");
-			return -1;
-		} else if (rematch_count == 0) {
-			// This should be impossible, since the global criteria is always
-			// present in a mako_config and matches everything.
-			fprintf(stderr, "Notification matched zero criteria?!\n");
-			return -1;
-		}
 	}
 
 	// Place all of the matches back into the list where the first one was

--- a/notification.c
+++ b/notification.c
@@ -475,5 +475,8 @@ int group_notifications(struct mako_state *state, struct mako_criteria *criteria
 	// originally.
 	wl_list_insert_list(location, &matches);
 
+	// We don't actually re-apply criteria here, that will happen just before
+	// we render each notification anyway.
+
 	return count;
 }

--- a/notification.c
+++ b/notification.c
@@ -53,12 +53,13 @@ void reset_notification(struct mako_notification *notif) {
 		free(notif->image_data);
 	}
 
-	notif->app_name = NULL;
-	notif->app_icon = NULL;
-	notif->summary = NULL;
-	notif->body = NULL;
-	notif->category = NULL;
-	notif->desktop_entry = NULL;
+	notif->app_name = strdup("");
+	notif->app_icon = strdup("");
+	notif->summary = strdup("");
+	notif->body = strdup("");
+	notif->category = strdup("");
+	notif->desktop_entry = strdup("");
+
 	notif->image_data = NULL;
 
 	destroy_icon(notif->icon);
@@ -77,6 +78,7 @@ struct mako_notification *create_notification(struct mako_state *state) {
 	++state->last_id;
 	notif->id = state->last_id;
 	wl_list_init(&notif->actions);
+	wl_list_init(&notif->link);
 	reset_notification(notif);
 
 	// Start ungrouped.

--- a/render.c
+++ b/render.c
@@ -320,7 +320,6 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 
 int render(struct mako_surface *surface, struct pool_buffer *buffer, int scale) {
 	struct mako_state *state = surface->state;
-	struct mako_config *config = &state->config;
 	cairo_t *cairo = buffer->cairo;
 
 	if (wl_list_empty(&state->notifications)) {
@@ -413,16 +412,15 @@ int render(struct mako_surface *surface, struct pool_buffer *buffer, int scale) 
 	}
 
 	if (hidden_count > 0) {
-		// Apply the hidden_style on top of the global style. This has to be
-		// done here since this notification isn't "real" and wasn't processed
-		// by apply_each_criteria.
-		struct mako_style style;
-		init_empty_style(&style);
-		apply_style(&style, &global_criteria(config)->style);
-		apply_style(&style, &config->hidden_style);
+		struct mako_notification *hidden_notif = create_notification(state);
+		hidden_notif->surface = surface;
+		hidden_notif->hidden = true;
+		apply_each_criteria(&state->config.criteria, hidden_notif);
 
-		if (style.margin.top > pending_bottom_margin) {
-			total_height += style.margin.top;
+		struct mako_style *style = &hidden_notif->style;
+
+		if (style->margin.top > pending_bottom_margin) {
+			total_height += style->margin.top;
 		} else {
 			total_height += pending_bottom_margin;
 		}
@@ -433,22 +431,22 @@ int render(struct mako_surface *surface, struct pool_buffer *buffer, int scale) 
 		};
 
 		size_t text_ln =
-			format_text(style.format, NULL, format_hidden_text, &data);
+			format_text(style->format, NULL, format_hidden_text, &data);
 		char *text = malloc(text_ln + 1);
 		if (text == NULL) {
 			fprintf(stderr, "allocation failed");
 			return 0;
 		}
 
-		format_text(style.format, text, format_hidden_text, &data);
+		format_text(style->format, text, format_hidden_text, &data);
 
 		int hidden_height = render_notification(
-			cairo, state, surface, &style, text, NULL, total_height, scale, NULL, 0);
+			cairo, state, surface, style, text, NULL, total_height, scale, NULL, 0);
 		free(text);
-		finish_style(&style);
+		destroy_notification(hidden_notif);
 
 		total_height += hidden_height;
-		pending_bottom_margin = style.margin.bottom;
+		pending_bottom_margin = style->margin.bottom;
 	}
 
 	return total_height + pending_bottom_margin;

--- a/render.c
+++ b/render.c
@@ -346,14 +346,15 @@ int render(struct mako_surface *surface, struct pool_buffer *buffer, int scale) 
 		}
 		++count;
 
-		if (surface->max_visible >= 0 &&
-				visible_count >= (size_t)surface->max_visible) {
-			continue;
-		}
 
 		// Note that by this point, everything in the style is guaranteed to
 		// be specified, so we don't need to check.
 		struct mako_style *style = &notif->style;
+
+		if (style->max_visible >= 0 &&
+				visible_count >= (size_t)style->max_visible) {
+			continue;
+		}
 
 		++i; // We count how many we've seen even if we're not rendering them.
 

--- a/render.c
+++ b/render.c
@@ -346,6 +346,22 @@ int render(struct mako_surface *surface, struct pool_buffer *buffer, int scale) 
 		}
 		++count;
 
+		// Immediately before rendering we need to re-match all of the criteria
+		// so that matches against the anchor and output work even if the
+		// output was automatically assigned by the compositor.
+		int rematch_count = apply_each_criteria(&state->config.criteria, notif);
+		if (rematch_count == -1) {
+			// We encountered an allocation failure or similar while applying
+			// criteria. The notification may be partially matched, but the
+			// worst case is that it has an empty style, so bail.
+			fprintf(stderr, "Failed to apply criteria\n");
+			break;
+		} else if (rematch_count == 0) {
+			// This should be impossible, since the global criteria is always
+			// present in a mako_config and matches everything.
+			fprintf(stderr, "Notification matched zero criteria?!\n");
+			break;
+		}
 
 		// Note that by this point, everything in the style is guaranteed to
 		// be specified, so we don't need to check.

--- a/surface.c
+++ b/surface.c
@@ -23,8 +23,7 @@ void destroy_surface(struct mako_surface *surface) {
 }
 
 struct mako_surface *create_surface(struct mako_state *state, const char *output,
-		enum zwlr_layer_shell_v1_layer layer, uint32_t anchor,
-		int32_t max_visible) {
+		enum zwlr_layer_shell_v1_layer layer, uint32_t anchor) {
 	struct mako_surface *surface = calloc(1, sizeof(*surface));
 	if (!surface) {
 		return NULL;
@@ -33,7 +32,6 @@ struct mako_surface *create_surface(struct mako_state *state, const char *output
 	surface->configured_output = strdup(output);
 	surface->layer = layer;
 	surface->anchor = anchor;
-	surface->max_visible = max_visible;
 	surface->state = state;
 
 	wl_list_insert(&state->surfaces, &surface->link);

--- a/types.c
+++ b/types.c
@@ -231,6 +231,30 @@ bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out) {
 	return true;
 }
 
+// Checks whether any of the fields of the given specification are set. Useful
+// for checking for some subset of fields without enumerating all known fields
+// yourself. Often you will want to copy a spec and clear fields you _don't_
+// care about to use this.
+bool mako_criteria_spec_any(const struct mako_criteria_spec *spec) {
+	return
+		spec->app_name ||
+		spec->app_icon ||
+		spec->actionable ||
+		spec->expiring ||
+		spec->urgency ||
+		spec->category ||
+		spec->desktop_entry ||
+		spec->summary ||
+		spec->summary_pattern ||
+		spec->body ||
+		spec->body_pattern ||
+		spec->none ||
+		spec->group_index ||
+		spec->grouped ||
+		spec->output ||
+		spec->anchor;
+}
+
 bool parse_format(const char *string, char **out) {
 	size_t token_max_length = strlen(string) + 1;
 	char token[token_max_length];

--- a/types.c
+++ b/types.c
@@ -251,6 +251,7 @@ bool mako_criteria_spec_any(const struct mako_criteria_spec *spec) {
 		spec->none ||
 		spec->group_index ||
 		spec->grouped ||
+		spec->hidden ||
 		spec->output ||
 		spec->anchor;
 }

--- a/types.c
+++ b/types.c
@@ -208,11 +208,19 @@ bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out) {
 			out->summary = true;
 		} else if (strcmp(token, "body") == 0) {
 			out->body = true;
+		} else if (strcmp(token, "grouped") == 0) {
+			out->grouped = true;
+		} else if (strcmp(token, "group-index") == 0) {
+			out->group_index = true;
+		} else if (strcmp(token, "anchor") == 0) {
+			out->anchor = true;
+		} else if (strcmp(token, "output") == 0) {
+			out->output = true;
 		} else if (strcmp(token, "none") == 0) {
 			out->none = true;
 		} else {
-			free(components);
 			fprintf(stderr, "Unknown criteria field '%s'\n", token);
+			free(components);
 			return false;
 		}
 
@@ -295,5 +303,31 @@ bool parse_format(const char *string, char **out) {
 	}
 
 	*out = strdup(token);
+	return true;
+}
+
+bool parse_anchor(const char *string, uint32_t *out) {
+	if (strcmp(string, "top-right") == 0) {
+		*out = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
+			ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
+	} else if (strcmp(string, "top-center") == 0) {
+		*out = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
+	} else if (strcmp(string, "top-left") == 0) {
+		*out = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
+			ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
+	} else if (strcmp(string, "bottom-right") == 0) {
+		*out = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
+			ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
+	} else if (strcmp(string, "bottom-center") == 0) {
+		*out = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
+	} else if (strcmp(string, "bottom-left") == 0) {
+		*out = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
+			ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
+	} else if (strcmp(string, "center") == 0) {
+		*out = 0;
+	} else {
+		return false;
+	}
+
 	return true;
 }

--- a/types.c
+++ b/types.c
@@ -326,6 +326,7 @@ bool parse_anchor(const char *string, uint32_t *out) {
 	} else if (strcmp(string, "center") == 0) {
 		*out = 0;
 	} else {
+		fprintf(stderr, "Invalid anchor value '%s'\n", string);
 		return false;
 	}
 


### PR DESCRIPTION
This is the result of a couple weeks of mulling over discussion from IRC about whether `max-visible` and `hidden` can be made to work as intended with implicit surfaces. TL;DR yes, but I'm marking this draft because it needs some feedback on whether this is actually the right approach, and if I missed any cases.

I added new criteria fields for `output` and `anchor`. The combination of these is effectively the same as giving surfaces names, because they are the two unique attribues of any surface. So now you can do this:
```
[output=DP-6 anchor=top-right]
background-color=#ffffff
max-visible=2
```
These are not magically applied to surfaces instead of notifications, though. They behave much like `grouped` and `group-index` already did: the first pass of criteria will potentially set them, and the second pass then re-styles the notifications based on their final values. It's still only two passes, so it's not possible to get into an infinite loop.

Treating them as normal styles allows you to do interesting things like I've done above, changing the appearance one last time for anything that appears on a given surface. It's a little weird to have `max-visible` stored on every notification rather than the surface, but it has the same effect since they all just happen to get the same value set.

On its own the above is insufficient, as it would allow specifying criteria that don't make sense:
```
[anchor=top-right]
group-by=anchor
```
This cannot possibly work, since we only do two passes. I noticed we already had some situations like this. For example at the moment you can specify `group-by` inside a criteria maching `grouped` which would just silently do nothing. I've made all of these impossible cases fail the config validation, and tried to give them useful messages as well.

TODO:
* ~Make it invalid to use `max_visible` inside criteria matching anything other than `anchor` and `output`. While you might be able to do clever things specifying it on other matches, it violates the principle of least astonishment as it would be applied in config order rather than by the smallest max-visible value. (In fact it's impossible to accomplish the latter even with a special case, due to the presence of the default value.)~ Done.
* ~Fix up `hidden` so you can style that per surface as well.~ Done.
* ~Much more testing.~ I've been running this since october and haven't seen any crashes or weird behavior.
* ~Finish adding new criteria to the manpage.~ Done.

Let me know what you think of this solution!