### PR TITLE
Add support for body criteria

### DIFF
--- a/include/criteria.h
+++ b/include/criteria.h
@@ -31,6 +31,7 @@ struct mako_criteria {
 	char *summary;
 	regex_t summary_pattern;
 	char *body;
+	regex_t body_pattern;
 	int group_index;
 	bool grouped;  // Whether group_index is non-zero
 };

--- a/include/types.h
+++ b/include/types.h
@@ -51,6 +51,7 @@ struct mako_criteria_spec {
 	bool summary;
 	bool summary_pattern;
 	bool body;
+	bool body_pattern;
 	bool group_index;
 	bool grouped;
 

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -248,6 +248,13 @@ The following fields are available in criteria:
 	- A POSIX extended regular expression match on the summary of the
 	  notification.
 	- This field conflicts with _summary_.
+- _body_ (string)
+	- An exact match on the body of the notification.
+	- This field conflicts with _body~_.
+- _body~_ (string)
+	- A POSIX extended regular expression match on the body of the
+	notification.
+	- This field conflicts with _body_.
 - _urgency_ (one of "low", "normal", "high")
 - _category_ (string)
 - _desktop-entry_ (string)


### PR DESCRIPTION
This adds the ability to match notifications based on notification bodies, either using an exact string match or an approximate regex. See issue #304.

I've based this almost entirely on the existing summary support - so, it should be at least as functional as that! Notably, there was also existing scaffolding for matching body criteria in the codebase. It was missing from config parsing, though, and from the documentation. Since the TODO in the original code mentioning body support described it as waiting for regex support, I've also added regex support for bodies, matching the existing regex support for summaries.

This was a fairly straightforward PR - the only real thing I did was pull out regex criteria matching, to avoid duplication between summaries and bodies - everything else is just directly copied and modified from the existing summary code.

Let me know if there's anything I can do. And I hope this is useful!

Fixes #304.