### PR TITLE
Change urgency level name

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -19,7 +19,7 @@ bool parse_mako_color(const char *string, struct mako_color *out);
 enum mako_notification_urgency {
 	MAKO_NOTIFICATION_URGENCY_LOW = 0,
 	MAKO_NOTIFICATION_URGENCY_NORMAL = 1,
-	MAKO_NOTIFICATION_URGENCY_HIGH = 2,
+	MAKO_NOTIFICATION_URGENCY_CRITICAL = 2,
 	MAKO_NOTIFICATION_URGENCY_UNKNOWN = -1,
 };
 

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -258,7 +258,7 @@ The following fields are available in criteria:
 	- A POSIX extended regular expression match on the body of the
 	notification.
 	- This field conflicts with _body_.
-- _urgency_ (one of "low", "normal", "high")
+- _urgency_ (one of "low", "normal", "critical")
 - _category_ (string)
 - _desktop-entry_ (string)
 - _actionable_ (boolean)

--- a/notification.c
+++ b/notification.c
@@ -376,7 +376,7 @@ static struct wl_list *get_last_notif_by_urgency(struct wl_list *notifications,
 		return notifications;
 	}
 
-	while (current <= MAKO_NOTIFICATION_URGENCY_HIGH &&
+	while (current <= MAKO_NOTIFICATION_URGENCY_CRITICAL &&
 		current >= MAKO_NOTIFICATION_URGENCY_UNKNOWN) {
 		struct mako_notification *notif;
 		wl_list_for_each_reverse(notif, notifications, link) {

--- a/types.c
+++ b/types.c
@@ -114,8 +114,11 @@ bool parse_urgency(const char *string, enum mako_notification_urgency *out) {
 	} else if (strcasecmp(string, "normal") == 0) {
 		*out = MAKO_NOTIFICATION_URGENCY_NORMAL;
 		return true;
+	} else if (strcasecmp(string, "critical") == 0) {
+		*out = MAKO_NOTIFICATION_URGENCY_CRITICAL;
+		return true;
 	} else if (strcasecmp(string, "high") == 0) {
-		*out = MAKO_NOTIFICATION_URGENCY_HIGH;
+		*out = MAKO_NOTIFICATION_URGENCY_CRITICAL;
 		return true;
 	}
 


### PR DESCRIPTION
Following the Gnome desktop notification specification, urgency levels are:
- low
- normal
- critical

See: https://developer.gnome.org/notification-spec/#urgency-levels

This seems to be also the case for notify-send command
https://www.galago-project.org/specs/notification/0.9/x320.html.

https://github.com/emersion/mako/issues/315