### PR TITLE
systemd: modernize wayland check

### DIFF
--- a/contrib/systemd/mako.service.in
+++ b/contrib/systemd/mako.service.in
@@ -3,11 +3,12 @@ Description=Lightweight Wayland notification daemon
 Documentation=man:mako(1)
 PartOf=graphical-session.target
 After=graphical-session.target
+# ConditionEnvironment requires systemd v247 to work correctly
+ConditionEnvironment=WAYLAND_DISPLAY
 
 [Service]
 Type=dbus
 BusName=org.freedesktop.Notifications
-ExecCondition=/bin/sh -c '[ -n "$WAYLAND_DISPLAY" ]'
 ExecStart=@bindir@/mako
 ExecReload=@bindir@/makoctl reload
 


### PR DESCRIPTION
systemd v247 should be released any day now.

ConditionEnvironment= directive was introducted in v246 but did not work
correctly until v247.

https://www.freedesktop.org/software/systemd/man/systemd.unit.html#ConditionEnvironment=

https://github.com/systemd/systemd/issues/16781
