### PR TITLE
mako.5.scd: fix typo

### DIFF
--- a/mako.5.scd
+++ b/mako.5.scd
@@ -91,7 +91,7 @@ _none_, _dismiss_, _dismiss-all_, _dismiss-group_, _invoke-default-action_,
 *border-size*=_px_
 	Set popup border size to _px_ pixels.
 
-	Default: 1
+	Default: 2
 
 *border-color*=_color_
 	Set popup border color to _color_. See *COLORS* for more information.


### PR DESCRIPTION
border-size: default=1 -> default=2

https://github.com/emersion/mako/blob/5f5e43f94a292c43f20ea7b98120a3bc880ec1d6/config.c#L87