### PR TITLE
Added support for specifying output by identifier for wlroots.

### DIFF
--- a/include/wayland.h
+++ b/include/wayland.h
@@ -17,6 +17,7 @@ struct mako_output {
 	struct wl_list link; // mako_state::outputs
 
 	char *name;
+	char *identifier;
 	enum wl_output_subpixel subpixel;
 	int32_t scale;
 };


### PR DESCRIPTION
This allows for the following setting:

```
output=Acer Technologies XF270HU SERIAL
```

Which would make it so that if your output adapter changes, it would still show up on the same monitor. Unfortunately for me, my monitor outputs change frequently.

I've made a similar PR for Waybar https://github.com/Alexays/Waybar/pull/956

The code for getting the identifier from the description is almost a direct copy paste from the swaybar implementation: https://github.com/swaywm/sway/pull/3415/files#diff-f1816f4a24dbbcf1a1dc419a0daeee3ac8bfcb410a44bd9d9e75900d1210bbbcR264-R279
