### PR TITLE
Fix manpage formatting

### DIFF
--- a/mako.5.scd
+++ b/mako.5.scd
@@ -170,8 +170,8 @@ _none_, _dismiss_, _dismiss-all_, _dismiss-group_, _invoke-default-action_,
 	more information. To change this for grouped notifications, set it within
 	a _grouped_ criteria.
 
-	Default: <b>%s</b>\\n%b
-	Default when grouped: (%g) <b>%s</b>\\n%b
+	Default: <b>%s</b>\\n%b++
+Default when grouped: (%g) <b>%s</b>\\n%b
 
 *default-timeout*=_timeout_
 	Set the default timeout to _timeout_ in milliseconds. To disable the


### PR DESCRIPTION
scdoc requires explicit line breaks. Without, this renders as:

`Default: <b>%s</b>\n%b Default when grouped: (%g) <b>%s</b>\n%b`

(Note: I'm not entirely sure whether this solution is correct: I didn't
apply indentation to the second line, as otherwise it is indented twice.
This might be a bug in scdoc, or could be its intended behaviour. Either
way, this was surprising to me, so I thought I'd mention just in case.)