### PR TITLE
Revert "Add `makoctl set`"

### DIFF
--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -312,27 +312,6 @@ static int handle_reload(sd_bus_message *msg, void *data,
 	return sd_bus_reply_method_return(msg, "");
 }
 
-static int handle_set_config_option(sd_bus_message *msg, void *data,
-		sd_bus_error *ret_error) {
-	struct mako_state *state = data;
-
-	const char *name = NULL, *value = NULL;
-	int ret = sd_bus_message_read(msg, "ss", &name, &value);
-	if (ret < 0) {
-		return ret;
-	}
-
-	if (!apply_global_option(&state->config, name, value)) {
-		sd_bus_error_set_const(ret_error, "fr.emersion.Mako.InvalidConfig",
-			"Failed to apply configuration option");
-		return -1;
-	}
-
-	reapply_config(state);
-
-	return sd_bus_reply_method_return(msg, "");
-}
-
 static const sd_bus_vtable service_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_METHOD("DismissAllNotifications", "", "", handle_dismiss_all_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
@@ -343,7 +322,6 @@ static const sd_bus_vtable service_vtable[] = {
 	SD_BUS_METHOD("RestoreNotification", "", "", handle_restore_action, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("ListNotifications", "", "aa{sv}", handle_list_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("Reload", "", "", handle_reload, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("SetConfigOption", "ss", "", handle_set_config_option, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END
 };
 

--- a/makoctl
+++ b/makoctl
@@ -21,7 +21,6 @@ usage() {
 	echo "                                 notification if none is given"
 	echo "  list                           List notifications"
 	echo "  reload                         Reload the configuration file"
-	echo "  set <key>=<value>              Set a global configuration option"
 	echo "  help                           Show this help"
 }
 
@@ -129,19 +128,6 @@ case "$1" in
 	;;
 "reload")
 	call Reload
-	;;
-"set")
-	if [ $# -lt 2 ]; then
-		echo >&2 "makoctl: missing argument for 'set'"
-		exit 1
-	fi
-	name="${2%%'='*}"
-	value="${2#*'='}"
-	if [ "$2" = "$name" ]; then
-		echo >&2 "makoctl: missing '=' in argument for 'set'"
-		exit 1
-	fi
-	call SetConfigOption "ss" "$name" "$value"
 	;;
 "help"|"--help"|"-h")
 	usage

--- a/makoctl.1.scd
+++ b/makoctl.1.scd
@@ -70,11 +70,6 @@ Sends IPC commands to the running mako daemon via dbus.
 *reload*
 	Reloads the configuration file.
 
-*set* <key>=<value>
-	Set a global configuration option.
-
-	Reloading the config will discard options set like this.
-
 *help, -h, --help*
 	Show help message and quit.
 


### PR DESCRIPTION
This reverts most of the changes made in commit 79f9dd39cd0c ("Add
`makoctl set`"). This change causes too many issues.

References: https://github.com/emersion/mako/issues/138