### PR TITLE
contrib: drop apparmor and systemd build-system integration

### DIFF
--- a/contrib/apparmor/meson.build
+++ b/contrib/apparmor/meson.build
@@ -1,8 +1,0 @@
-if get_option('apparmor')
-	apparmordir = join_paths(get_option('sysconfdir'), 'apparmor.d')
-	install_data(
-		'fr.emersion.Mako',
-		install_dir: apparmordir,
-		install_mode: 'rw-r-----',
-	)
-endif

--- a/contrib/systemd/mako.service
+++ b/contrib/systemd/mako.service
@@ -9,8 +9,8 @@ ConditionEnvironment=WAYLAND_DISPLAY
 [Service]
 Type=dbus
 BusName=org.freedesktop.Notifications
-ExecStart=@bindir@/mako
-ExecReload=@bindir@/makoctl reload
+ExecStart=/usr/bin/mako
+ExecReload=/usr/bin/makoctl reload
 
 [Install]
 WantedBy=graphical-session.target

--- a/meson.build
+++ b/meson.build
@@ -126,19 +126,6 @@ configure_file(
 	install_dir: datadir + '/dbus-1/services',
 )
 
-systemd = dependency('systemd', required: get_option('systemd'))
-
-if systemd.found()
-  user_units_dir = systemd.get_pkgconfig_variable('systemduserunitdir')
-
-  configure_file(
-    configuration: conf_data,
-    input: 'contrib/systemd/mako.service.in',
-    output: '@BASENAME@',
-    install_dir: user_units_dir
-  )
-endif
-
 scdoc = dependency('scdoc', required: get_option('man-pages'), version: '>= 1.9.7')
 
 if scdoc.found()

--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,6 @@ if gdk_pixbuf.found()
 	add_global_arguments('-DHAVE_ICONS=1', language: 'c')
 endif
 
-subdir('contrib/apparmor')
 subdir('contrib/completions')
 subdir('protocol')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,4 +3,3 @@ option('icons', type: 'feature', value: 'auto', description: 'Enable icon suppor
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('fish-completions', type: 'boolean', value: false, description: 'Install fish completions')
 option('zsh-completions', type: 'boolean', value: false, description: 'Install zsh completions')
-option('systemd', type: 'feature', value: 'auto', description: 'Install systemd user service unit')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,5 +3,4 @@ option('icons', type: 'feature', value: 'auto', description: 'Enable icon suppor
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('fish-completions', type: 'boolean', value: false, description: 'Install fish completions')
 option('zsh-completions', type: 'boolean', value: false, description: 'Install zsh completions')
-option('apparmor', type: 'boolean', value: 'false', description: 'Install AppArmor profile')
 option('systemd', type: 'feature', value: 'auto', description: 'Install systemd user service unit')


### PR DESCRIPTION
We get too many distribution-specific bug reports about them.

Let's not install these by default. Let's leave it to distributions to adapt and ship these.