### PR TITLE
Add text-alignment option

### DIFF
--- a/config.c
+++ b/config.c
@@ -98,6 +98,7 @@ void init_default_style(struct mako_style *style) {
 	style->font = strdup("monospace 10");
 	style->markup = true;
 	style->format = strdup("<b>%s</b>\n%b");
+	style->text_alignment = PANGO_ALIGN_LEFT;
 
 	style->actions = true;
 	style->default_timeout = 0;
@@ -242,6 +243,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 		free(target->format);
 		target->format = new_format;
 		target->spec.format = true;
+	}
+
+	if (style->spec.text_alignment) {
+		target->text_alignment = style->text_alignment;
+		target->spec.text_alignment = true;
 	}
 
 	if (style->spec.actions) {
@@ -537,6 +543,18 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	} else if (strcmp(name, "format") == 0) {
 		free(style->format);
 		return spec->format = parse_format(value, &style->format);
+	} else if (strcmp(name, "text-alignment") == 0) {
+		if (strcmp(value, "left") == 0) {
+			style->text_alignment = PANGO_ALIGN_LEFT;
+		} else if (strcmp(value, "center") == 0) {
+			style->text_alignment = PANGO_ALIGN_CENTER;
+		} else if (strcmp(value, "right") == 0) {
+			style->text_alignment = PANGO_ALIGN_RIGHT;
+		} else {
+			return false;
+		}
+		style->spec.text_alignment = true;
+		return true;
 	} else if (strcmp(name, "default-timeout") == 0) {
 		return spec->default_timeout =
 			parse_int_ge(value, &style->default_timeout, 0);

--- a/include/config.h
+++ b/include/config.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <wayland-client.h>
+#include <pango/pango.h>
 #include "types.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
@@ -32,8 +33,8 @@ enum mako_icon_location {
 // structs are also mirrored.
 struct mako_style_spec {
 	bool width, height, margin, padding, border_size, border_radius, font,
-		markup, format, actions, default_timeout, ignore_timeout, icons,
-		max_icon_size, icon_path, group_criteria_spec, invisible, history,
+		markup, format, text_alignment, actions, default_timeout, ignore_timeout,
+		icons, max_icon_size, icon_path, group_criteria_spec, invisible, history,
 		icon_location, max_visible, layer, output, anchor;
 	struct {
 		bool background, text, border, progress;
@@ -58,6 +59,7 @@ struct mako_style {
 	char *font;
 	bool markup;
 	char *format;
+	PangoAlignment text_alignment;
 
 	bool actions;
 	int default_timeout; // in ms

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -173,6 +173,11 @@ _none_, _dismiss_, _dismiss-all_, _dismiss-group_, _invoke-default-action_,
 	Default: <b>%s</b>\\n%b++
 Default when grouped: (%g) <b>%s</b>\\n%b
 
+*text-alignment*=left|center|right
+	Set notification text alignment.
+
+	Default: left
+
 *default-timeout*=_timeout_
 	Set the default timeout to _timeout_ in milliseconds. To disable the
 	timeout, set it to zero.

--- a/render.c
+++ b/render.c
@@ -143,6 +143,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 
 	PangoLayout *layout = pango_cairo_create_layout(cairo);
 	set_layout_size(layout, text_layout_width, text_layout_height, scale);
+	pango_layout_set_alignment(layout, style->text_alignment);
 	pango_layout_set_wrap(layout, PANGO_WRAP_WORD_CHAR);
 	pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
 	PangoFontDescription *desc =


### PR DESCRIPTION
This option sets text alignment in the notifications like `dunst`. Possible values are: `left`, `center` or `right`