### PR TITLE
Implement xdg-activation-v1

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -1,4 +1,4 @@
-image: alpine/latest
+image: alpine/edge
 packages:
   - elogind-dev
   - meson

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -109,7 +109,7 @@ static int handle_invoke_action(sd_bus_message *msg, void *data,
 			struct mako_action *action;
 			wl_list_for_each(action, &notif->actions, link) {
 				if (strcmp(action->key, action_key) == 0) {
-					notify_action_invoked(action);
+					notify_action_invoked(action, NULL);
 					break;
 				}
 			}

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -489,13 +489,19 @@ void notify_notification_closed(struct mako_notification *notif,
 		"NotificationClosed", "uu", notif->id, reason);
 }
 
-void notify_action_invoked(struct mako_action *action) {
+void notify_action_invoked(struct mako_action *action,
+		const char *activation_token) {
 	if (!action->notification->style.actions) {
 		// Actions are disabled for this notification, bail.
 		return;
 	}
 
 	struct mako_state *state = action->notification->state;
+
+	if (activation_token != NULL) {
+		sd_bus_emit_signal(state->bus, service_path, service_interface,
+			"ActivationToken", "us", action->notification->id, activation_token);
+	}
 
 	sd_bus_emit_signal(state->bus, service_path, service_interface,
 		"ActionInvoked", "us", action->notification->id, action->key);

--- a/include/dbus.h
+++ b/include/dbus.h
@@ -20,7 +20,8 @@ void finish_dbus(struct mako_state *state);
 void notify_notification_closed(struct mako_notification *notif,
 	enum mako_notification_close_reason reason);
 
-void notify_action_invoked(struct mako_action *action);
+void notify_action_invoked(struct mako_action *action,
+	const char *activation_token);
 
 int init_dbus_xdg(struct mako_state *state);
 

--- a/include/mako.h
+++ b/include/mako.h
@@ -17,6 +17,7 @@
 #include "pool-buffer.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #include "xdg-output-unstable-v1-client-protocol.h"
+#include "xdg-activation-v1-client-protocol.h"
 
 struct mako_state;
 
@@ -56,6 +57,7 @@ struct mako_state {
 	struct wl_shm *shm;
 	struct zwlr_layer_shell_v1 *layer_shell;
 	struct zxdg_output_manager_v1 *xdg_output_manager;
+	struct xdg_activation_v1 *xdg_activation;
 	struct wl_list outputs; // mako_output::link
 	struct wl_list seats; // mako_seat::link
 	struct wl_cursor_theme *cursor_theme;

--- a/include/notification.h
+++ b/include/notification.h
@@ -70,6 +70,12 @@ struct mako_hidden_format_data {
 	size_t count;
 };
 
+struct mako_binding_context {
+	struct mako_surface *surface;
+	struct mako_seat *seat;
+	uint32_t serial;
+};
+
 #define DEFAULT_ACTION_KEY "default"
 
 typedef char *(*mako_format_func_t)(char variable, bool *markup, void *data);
@@ -94,10 +100,11 @@ struct mako_notification *get_tagged_notification(struct mako_state *state, cons
 size_t format_notification(struct mako_notification *notif, const char *format,
 	char *buf);
 void notification_handle_button(struct mako_notification *notif, uint32_t button,
-	enum wl_pointer_button_state state);
-void notification_handle_touch(struct mako_notification *notif);
+	enum wl_pointer_button_state state, const struct mako_binding_context *ctx);
+void notification_handle_touch(struct mako_notification *notif,
+	const struct mako_binding_context *ctx);
 void notification_execute_binding(struct mako_notification *notif,
-	enum mako_binding binding);
+	enum mako_binding binding, const struct mako_binding_context *ctx);
 void insert_notification(struct mako_state *state, struct mako_notification *notif);
 int group_notifications(struct mako_state *state, struct mako_criteria *criteria);
 

--- a/include/wayland.h
+++ b/include/wayland.h
@@ -29,12 +29,14 @@ struct mako_seat {
 	struct {
 		struct wl_pointer *wl_pointer;
 		int32_t x, y;
+		struct mako_surface *surface;
 	} pointer;
 
 	struct {
 		struct wl_touch *wl_touch;
 		struct {
 			int32_t x, y;
+			struct mako_surface *surface;
 		} pts[MAX_TOUCHPOINTS];
 	} touch;
 };

--- a/include/wayland.h
+++ b/include/wayland.h
@@ -44,5 +44,7 @@ struct mako_seat {
 bool init_wayland(struct mako_state *state);
 void finish_wayland(struct mako_state *state);
 void set_dirty(struct mako_surface *surface);
+char *create_xdg_activation_token(struct mako_surface *surface,
+	struct mako_seat *seat, uint32_t serial);
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ glib = dependency('glib-2.0')
 gobject = dependency('gobject-2.0')
 realtime = cc.find_library('rt')
 wayland_client = dependency('wayland-client')
-wayland_protos = dependency('wayland-protocols', version: '>=1.14')
+wayland_protos = dependency('wayland-protocols', version: '>=1.21')
 wayland_cursor = dependency('wayland-cursor')
 
 epoll = dependency('', required: false)

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -23,6 +23,7 @@ wayland_scanner_client = generator(
 
 client_protocols = [
 	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
+	[wl_protocol_dir, 'staging/xdg-activation/xdg-activation-v1.xml'],
 	[wl_protocol_dir, 'unstable/xdg-output/xdg-output-unstable-v1.xml'],
 	['wlr-layer-shell-unstable-v1.xml'],
 ]


### PR DESCRIPTION
This allows us to pass down an activation token to the invoked
notification. The receiver can then use the token to activate
its toplevel.

The Wayland protocol has been added in [1] and the D-Bus spec
additions are in [2].

[1]: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/50
[2]: https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/43