### PR TITLE
Add missing declaration of fish_comp

### DIFF
--- a/contrib/completions/meson.build
+++ b/contrib/completions/meson.build
@@ -11,6 +11,7 @@ endif
 
 if get_option('fish-completions')
 	fish_files = files('fish/mako.fish')
+	fish_comp = dependency('fish', required: false)
 	if fish_comp.found()
 		fish_install_dir = fish_comp.get_pkgconfig_variable('completionsdir')
 	else


### PR DESCRIPTION
Compiling with `-Dfish-completions` seems to fail with
```
contrib/completions/meson.build:14:14: ERROR: Unknown variable "fish_comp".
```
I guess @ammgws meant to have a declaration like this. However I have no clue what I'm doing :sweat_smile:, but this seems to compile and install as expected.