### PR TITLE
We need to move format slot only if a new specifier has been found

### DIFF
--- a/config.c
+++ b/config.c
@@ -414,7 +414,7 @@ bool apply_superset_style(
 				memcpy(&current_specifier, format_pos, 2);
 				if (!strstr(target->format, current_specifier)) {
 					memcpy(target_format_pos, format_pos, 2);
-                    target_format_pos += 2; // This needs to go to the next slot.
+					target_format_pos += 2; // This needs to go to the next slot.
 				}
 
 				++format_pos; // Enough to move to the next match.

--- a/config.c
+++ b/config.c
@@ -414,10 +414,10 @@ bool apply_superset_style(
 				memcpy(&current_specifier, format_pos, 2);
 				if (!strstr(target->format, current_specifier)) {
 					memcpy(target_format_pos, format_pos, 2);
+                    target_format_pos += 2; // This needs to go to the next slot.
 				}
 
 				++format_pos; // Enough to move to the next match.
-				target_format_pos += 2; // This needs to go to the next slot.
 			}
 		}
 	}


### PR DESCRIPTION
Quite blind fix for this config file that create an out of bound write:

```
format=%a %s %b

[grouped]
format=%a %g %s %b

[hidden]
format=%h %t
```

```
Starting program: /usr/bin/mako 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".
malloc(): invalid next size (unsorted)

Program received signal SIGABRT, Aborted.
0x00007ffff79e1d22 in raise () from /usr/lib/libc.so.6
(gdb) bt
#0  0x00007ffff79e1d22 in raise () at /usr/lib/libc.so.6
#1  0x00007ffff79cb862 in abort () at /usr/lib/libc.so.6
#2  0x00007ffff7a23d28 in __libc_message () at /usr/lib/libc.so.6
#3  0x00007ffff7a2b92a in  () at /usr/lib/libc.so.6
#4  0x00007ffff7a2ed6c in _int_malloc () at /usr/lib/libc.so.6
#5  0x00007ffff7a30397 in malloc () at /usr/lib/libc.so.6
#6  0x00007ffff7c2b19b in sd_bus_new () at /usr/lib/libsystemd.so.0
#7  0x00007ffff7c33d1d in sd_bus_open_user_with_description () at /usr/lib/libsystemd.so.0
#8  0x000055555555a0e9 in  ()
#9  0x00007ffff79ccb25 in __libc_start_main () at /usr/lib/libc.so.6
#10 0x000055555555abce in  ()
```

Valgrind tell us:
```
==2743== Invalid write of size 2
==2743==    at 0x1143BE: UnknownInlinedFun (string_fortified.h:29)
==2743==    by 0x1143BE: UnknownInlinedFun (config.c:416)
==2743==    by 0x1143BE: reload_config (config.c:863)
==2743==    by 0x10E0AC: main (main.c:105)
==2743==  Address 0x5c4c716 is 7 bytes after a block of size 15 alloc'd
==2743==    at 0x48435FF: calloc (vg_replace_malloc.c:1117)
==2743==    by 0x114068: UnknownInlinedFun (config.c:365)
==2743==    by 0x114068: reload_config (config.c:863)
==2743==    by 0x10E0AC: main (main.c:105)
```