### PR TITLE
Add missing fish completions

### DIFF
--- a/contrib/completions/fish/mako.fish
+++ b/contrib/completions/fish/mako.fish
@@ -27,6 +27,8 @@ complete -c mako -l actions -d 'Enable actions or not' -xa "1 0"
 complete -c mako -l format -d 'Format string' -x
 complete -c mako -l hidden-format -d 'Hidden format string' -x
 complete -c mako -l max-visible -d 'Max visible notifications' -x
+complete -c mako -l max-history -d 'Max size of history buffer' -x
+complete -c mako -l history -d 'Add expired notifications to history' -xa "1 0"
 complete -c mako -l sort -d 'Set notification sorting method' -x
 complete -c mako -l default-timeout -d 'Notification timeout in ms' -x
 complete -c mako -l ignore-timeout -d 'Enable notification timeout or not' -xa "1 0"

--- a/contrib/completions/fish/makoctl.fish
+++ b/contrib/completions/fish/makoctl.fish
@@ -1,0 +1,24 @@
+function __fish_makoctl_complete_no_subcommand
+	for i in (commandline -opc)
+		if contains -- $i dismiss restore invoke menu list reload help
+			return 1
+		end
+	end
+	return 0
+end
+
+complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a dismiss -d 'Dismiss notification (the last one if none is given)' -x
+complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a restore -d 'Restore the most recently expired notification from the history buffer' -x
+complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a invoke -d 'Invoke an action on the notification (the last one if none is given)' -x
+complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a menu -d 'Use a program to select one action to be invoked on the notification (the last one if none is given)' -x
+complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a list -d 'List notifications' -x
+complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a reload -d 'Reload the configuration file' -x
+complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a help -d 'Show help message and quit' -x
+
+complete -c makoctl -n '__fish_seen_subcommand_from dismiss' -s a -l all -d "Dismiss all notifications" -x
+complete -c makoctl -n '__fish_seen_subcommand_from dismiss' -s g -l group -d "Dismiss all the notifications in the last notification's group" -x
+complete -c makoctl -n '__fish_seen_subcommand_from dismiss' -s n -d "Dismiss the notification with the given id" -x
+complete -c makoctl -n '__fish_seen_subcommand_from invoke' -s n -d "Invoke an action on the notification with the given id" -x
+complete -c makoctl -n '__fish_seen_subcommand_from menu' -s n -d "Use a program to select one action on the notification with the given id" -x
+complete -c makoctl -n '__fish_seen_subcommand_from menu' -a "(__fish_complete_command)" -x
+

--- a/contrib/completions/meson.build
+++ b/contrib/completions/meson.build
@@ -10,7 +10,7 @@ if get_option('zsh-completions')
 endif
 
 if get_option('fish-completions')
-	fish_files = files('fish/mako.fish')
+	fish_files = files('fish/mako.fish', 'fish/makoctl.fish')
 	fish_comp = dependency('fish', required: false)
 	if fish_comp.found()
 		fish_install_dir = fish_comp.get_pkgconfig_variable('completionsdir')

--- a/contrib/completions/zsh/_mako
+++ b/contrib/completions/zsh/_mako
@@ -28,4 +28,4 @@ _arguments \
     '--output[Show notifications on this output.]:name:' \
     '--layer[Arrange notifications at this layer.]:layer:(background bottom top overlay)' \
     '--anchor[Position on output to put notifications.]:position:(top-right bottom-right bottom-center bottom-left top-left top-center center-right center-left center)' \
-    '--sort[Sorts incoming notifications by time and/or priority in ascending(+) or descending(-) order.]:sort pattern:'
+    '--sort[Sort incoming notifications by time and/or priority in ascending(+) or descending(-) order.]:sort pattern:'

--- a/contrib/completions/zsh/_makoctl
+++ b/contrib/completions/zsh/_makoctl
@@ -3,11 +3,11 @@
 local -a makoctl_cmds
 
 makoctl_cmds=(
-	'dismiss:Dismisses notification (first by default)'
+	'dismiss:Dismiss notification (first by default)'
 	'restore:Restore the most recently expired notification from the history buffer'
-	'invoke:Invokes an action on the first notification. If action is not specified, invokes the default action'
+	'invoke:Invoke an action on the first notification. If action is not specified, invoke the default action'
 	'list:Retrieve a list of current notifications'
-	'reload:Reloads the configuration file'
+	'reload:Reload the configuration file'
 	'help:Show help message and quit'
 )
 

--- a/main.c
+++ b/main.c
@@ -42,7 +42,7 @@ static const char usage[] =
 	"      --hidden-format <format>        Format string.\n"
 	"      --max-visible <n>               Max number of visible notifications.\n"
 	"      --max-history <n>               Max size of history buffer.\n"
-	"      --history <0|1>                 Add expired notificatinos to history.\n"
+	"      --history <0|1>                 Add expired notifications to history.\n"
 	"      --sort <sort_criteria>          Sorts incoming notifications by time\n"
 	"                                      and/or priority in ascending(+) or\n"
 	"                                      descending(-) order.\n"


### PR DESCRIPTION
This PR does these:

- Fix a small typo in mako --help
- Add missing fish completions for makoctl
- Keep verbs consistent in zsh completions

I don't know zsh well so I can't update the completions for zsh.
