### PR TITLE
New Feature: Change cursor when mouse moves over a notification

### DIFF
--- a/include/mako.h
+++ b/include/mako.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <wayland-client.h>
+#include <wayland-cursor.h>
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-bus.h>
 #elif HAVE_LIBELOGIND
@@ -57,6 +58,9 @@ struct mako_state {
 	struct zxdg_output_manager_v1 *xdg_output_manager;
 	struct wl_list outputs; // mako_output::link
 	struct wl_list seats; // mako_seat::link
+	struct wl_cursor_theme *cursor_theme;
+	const struct wl_cursor_image *cursor_image;
+	struct wl_surface *cursor_surface;
 
 	struct wl_list surfaces; // mako_surface::link
 

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,7 @@ gobject = dependency('gobject-2.0')
 realtime = cc.find_library('rt')
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
+wayland_cursor = dependency('wayland-cursor')
 
 epoll = dependency('', required: false)
 if (not cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>') or
@@ -105,6 +106,7 @@ executable(
 		gobject,
 		realtime,
 		wayland_client,
+		wayland_cursor,
 	],
 	include_directories: [mako_inc],
 	install: true,


### PR DESCRIPTION
Mako is really cool, but I noticed that when I moved my mouse over it the cursor would stay the same as what it was before. If it was an ibeam, it would stay an ibeam, and if it was normal, it would stay normal. I made it change to the cursor that is shown when you hover over a button, since it felt weird clicking on notifications before.

These websites were very helpful when I created this PR:
https://bugaevc.gitbooks.io/writing-wayland-clients/content/beyond-the-black-square/cursors.html
https://doc.qt.io/qt-5/qcursor.html#a-note-for-x11-users

The one flaw in this PR is if a notification has rounded corners, it will change the cursor even where the corners have been rounded off. Clicking in that area still makes the notification go away, though, so I think its fine.

I had to add a dependency to get this to work: wayland-cursor.