### PR TITLE
build: find scdoc is build system instead of target

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,10 +130,10 @@ configure_file(
 	install_dir: datadir + '/dbus-1/services',
 )
 
-scdoc = dependency('scdoc', required: get_option('man-pages'), version: '>= 1.9.7')
+scdoc = dependency('scdoc', required: get_option('man-pages'), version: '>= 1.9.7', native: true)
 
 if scdoc.found()
-	sh = find_program('sh')
+	sh = find_program('sh', native: true)
 
 	man_pages = ['mako.1.scd', 'mako.5.scd', 'makoctl.1.scd']
 

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -1,6 +1,6 @@
 wl_protocol_dir = wayland_protos.get_pkgconfig_variable('pkgdatadir')
 
-wayland_scanner = find_program('wayland-scanner')
+wayland_scanner = find_program('wayland-scanner', native: true)
 
 # should check wayland_scanner's version, but it is hard to get
 if wayland_client.version().version_compare('>=1.14.91')


### PR DESCRIPTION
For supporting cross compilation.
See: https://github.com/void-linux/void-packages/commit/b07214b837b4bba0fc6ad3e1ea226fcd5335ec6d