### PR TITLE
Include <errno.h> to use errno in wayland.c

### DIFF
--- a/wayland.c
+++ b/wayland.c
@@ -1,5 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Without the include, using `errno` results in compile error in some environments.