### PR TITLE
Feature get-mode

### DIFF
--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -302,6 +302,13 @@ static void reapply_config(struct mako_state *state) {
 	}
 }
 
+static int handle_get_mode(sd_bus_message *msg, void* data,
+		sd_bus_error *ret_error) {
+	struct mako_state* state = data;
+
+	return sd_bus_reply_method_return(msg, "s", state->current_mode);
+}
+
 static int handle_set_mode(sd_bus_message *msg, void *data,
 		sd_bus_error *ret_error) {
 	struct mako_state *state = data;
@@ -346,6 +353,7 @@ static const sd_bus_vtable service_vtable[] = {
 	SD_BUS_METHOD("RestoreNotification", "", "", handle_restore_action, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("ListNotifications", "", "aa{sv}", handle_list_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("Reload", "", "", handle_reload, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("GetMode", "", "s", handle_get_mode, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("SetMode", "s", "", handle_set_mode, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END
 };

--- a/makoctl
+++ b/makoctl
@@ -21,6 +21,7 @@ usage() {
 	echo "                                 notification if none is given"
 	echo "  list                           List notifications"
 	echo "  reload                         Reload the configuration file"
+	echo "  get-mode                       Show the current mode"
 	echo "  set-mode <name>                Switch the current mode"
 	echo "  help                           Show this help"
 }
@@ -130,6 +131,13 @@ case "$1" in
 "reload")
 	call Reload
 	;;
+"get-mode")
+    if ! type jq >/dev/null 2>&1; then
+        echo >&2 "$0: jq is required to use 'get-mode'"
+        exit 1
+    fi
+    call GetMode | jq -r '.data[]'
+    ;;
 "set-mode")
 	call SetMode "s" "$2"
 	;;

--- a/makoctl.1.scd
+++ b/makoctl.1.scd
@@ -70,6 +70,11 @@ Sends IPC commands to the running mako daemon via dbus.
 *reload*
 	Reloads the configuration file.
 
+*get-mode*
+	Retrieves the current mode.
+
+	See the _MODES_ section in **mako**(5) for more information about modes.
+
 *set-mode* <name>
 	Switches the current mode to _name_. This replaces the previous mode.
 

--- a/makoctl.1.scd
+++ b/makoctl.1.scd
@@ -65,7 +65,7 @@ Sends IPC commands to the running mako daemon via dbus.
 		```
 
 *list*
-	Retrieve a list of current notifications.
+	Retrieves a list of current notifications.
 
 *reload*
 	Reloads the configuration file.


### PR DESCRIPTION
Hi all,

Add a `get-mode` command to makoctl to retrieve the current mode and a `toggle-mode` command to go back and forth between a mode and default (Eg. to (de)activate a 'do-not-disturb' mode).

Personally these are 2 commands I would use, but I got no clue about how the project is used in other environment.

EDIT: accordingly to the discussion below the `toggle-mode` feature has been discarded and will come in its own PR.