### PR TITLE
Fix bad conditional in systemd service file

### DIFF
--- a/contrib/systemd/mako.service
+++ b/contrib/systemd/mako.service
@@ -3,12 +3,11 @@ Description=Lightweight Wayland notification daemon
 Documentation=man:mako(1)
 PartOf=graphical-session.target
 After=graphical-session.target
-# ConditionEnvironment requires systemd v247 to work correctly
-ConditionEnvironment=WAYLAND_DISPLAY
 
 [Service]
 Type=dbus
 BusName=org.freedesktop.Notifications
+ExecCondition=/bin/sh -c '[ -n "$WAYLAND_DISPLAY" ]'
 ExecStart=/usr/bin/mako
 ExecReload=/usr/bin/makoctl reload
 


### PR DESCRIPTION
The existing systemd.service(5) file has a `ConditionEnvironment` check.
This check is verified by systemd **once** the first time there is an
attempt to start mako. If the check fails, the service is moved to a
"cannot be started" state, and systemd will refuse to start it for the
rest of the session.

This is problematic; if any application tries to send a notification
before sway starts (or after killing sway and before starting another
instance), mako will remain in this "unstartable" state which requires
manual intervention.

This new check (`ExecCondition`) is evaluated every time there is an
attempt to start mako. If a cli application tries to send a notification
before sway has started, mako won't start, however, it also won't be
marked as "unstartable". If sway is later started and another
application tries to send a notification, mako will start normally.