### PR TITLE
Store multiple modes

### DIFF
--- a/criteria.c
+++ b/criteria.c
@@ -58,6 +58,18 @@ static bool match_regex_criteria(regex_t *pattern, char *value) {
 	return true;
 }
 
+bool check_in_list(const char *key, char **const list) {
+	char **lp = list;
+	while (*lp) {
+		if (strcmp(key, *lp) == 0) {
+			fprintf(stderr, "check_in_list: found matching mode %s\n", *lp);
+			return true;
+		}
+		lp++;
+	}
+	return false;
+}
+
 bool match_criteria(struct mako_criteria *criteria,
 		struct mako_notification *notif) {
 	struct mako_criteria_spec spec = criteria->spec;
@@ -152,7 +164,7 @@ bool match_criteria(struct mako_criteria *criteria,
 		return false;
 	}
 
-	if (spec.mode && strcmp(criteria->mode, notif->state->current_mode) != 0) {
+	if (spec.mode && !check_in_list(criteria->mode, notif->state->current_mode)) {
 		return false;
 	}
 

--- a/include/mako.h
+++ b/include/mako.h
@@ -74,7 +74,7 @@ struct mako_state {
 	uint32_t last_id;
 	struct wl_list notifications; // mako_notification::link
 	struct wl_list history; // mako_notification::link
-	char *current_mode;
+	char **current_mode;
 
 	int argc;
 	char **argv;

--- a/main.c
+++ b/main.c
@@ -72,11 +72,16 @@ static bool init(struct mako_state *state) {
 	}
 	wl_list_init(&state->notifications);
 	wl_list_init(&state->history);
-	state->current_mode = strdup("default");
+	state->current_mode = calloc(sizeof(char*), 2);
+	*state->current_mode = strdup("default");
 	return true;
 }
 
 static void finish(struct mako_state *state) {
+	char **cp = state->current_mode;
+	while (*cp) {
+		free(*cp++);
+	}
 	free(state->current_mode);
 
 	struct mako_notification *notif, *tmp;


### PR DESCRIPTION
I added this to mostly allow different themes (dark/light) and the ability to add a do not disturb mode.
This allows me to add a mode `+silent` and delete `-silent` it again without having to know the current state of the theme.
But I guess it could be also used in different ways, I did not think about all use cases and all the problems which could arise here.
Just wanted to share this and hear if that would be something that would make sense to or [not](https://github.com/emersion/mako/issues/335#issuecomment-831437588).

No extra documentation for now, a little bit in the commit message, just wanted to get some feedback for now if it makes sense to go in this direction, thanks.