### PR TITLE
Add support for multiple modes

### DIFF
--- a/criteria.c
+++ b/criteria.c
@@ -11,6 +11,7 @@
 #include "mako.h"
 #include "config.h"
 #include "criteria.h"
+#include "mode.h"
 #include "notification.h"
 #include "surface.h"
 #include "wayland.h"
@@ -152,7 +153,7 @@ bool match_criteria(struct mako_criteria *criteria,
 		return false;
 	}
 
-	if (spec.mode && strcmp(criteria->mode, notif->state->current_mode) != 0) {
+	if (spec.mode && has_mode(notif->state, criteria->mode)) {
 		return false;
 	}
 

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -9,6 +9,7 @@
 #include "surface.h"
 #include "dbus.h"
 #include "mako.h"
+#include "mode.h"
 #include "notification.h"
 #include "wayland.h"
 
@@ -312,8 +313,7 @@ static int handle_set_mode(sd_bus_message *msg, void *data,
 		return ret;
 	}
 
-	free(state->current_mode);
-	state->current_mode = strdup(mode);
+	set_modes(state, &mode, 1);
 
 	reapply_config(state);
 

--- a/include/mako.h
+++ b/include/mako.h
@@ -74,7 +74,7 @@ struct mako_state {
 	uint32_t last_id;
 	struct wl_list notifications; // mako_notification::link
 	struct wl_list history; // mako_notification::link
-	char *current_mode;
+	struct wl_array current_modes; // char *
 
 	int argc;
 	char **argv;

--- a/include/mode.h
+++ b/include/mode.h
@@ -1,0 +1,11 @@
+#ifndef MODE_H
+#define MODE_H
+
+#include <stdbool.h>
+
+struct mako_state;
+
+bool has_mode(struct mako_state *state, const char *mode);
+void set_modes(struct mako_state *state, const char **modes, size_t modes_len);
+
+#endif

--- a/main.c
+++ b/main.c
@@ -7,6 +7,7 @@
 #include "config.h"
 #include "dbus.h"
 #include "mako.h"
+#include "mode.h"
 #include "notification.h"
 #include "render.h"
 #include "surface.h"
@@ -72,12 +73,18 @@ static bool init(struct mako_state *state) {
 	}
 	wl_list_init(&state->notifications);
 	wl_list_init(&state->history);
-	state->current_mode = strdup("default");
+	wl_array_init(&state->current_modes);
+	const char *mode = "default";
+	set_modes(state, &mode, 1);
 	return true;
 }
 
 static void finish(struct mako_state *state) {
-	free(state->current_mode);
+	char **mode_ptr;
+	wl_array_for_each(mode_ptr, &state->current_modes) {
+		free(*mode_ptr);
+	}
+	wl_array_release(&state->current_modes);
 
 	struct mako_notification *notif, *tmp;
 	wl_list_for_each_safe(notif, tmp, &state->notifications, link) {

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -437,8 +437,8 @@ enabled:
 invisible=1
 ```
 
-_makoctl set-mode do-not-disturb_ will hide all notifications,
-_makoctl set-mode default_ will show them again.
+_makoctl mode -a do-not-disturb_ will hide all notifications,
+_makoctl mode -r do-not-disturb_ will show them again.
 
 # AUTHORS
 

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -427,7 +427,8 @@ mako supports applying style options conditionally via modes. A configuration
 section with a _mode_ criteria will only be applied if the current mode
 matches. **makoctl**(1) can be used to change the current mode.
 
-The default mode is named "default".
+The initial list of modes contains a single mode called "default". This is
+deprecated, in a future version the initial list of modes will be empty.
 
 For example, to hide all notifications if the mode "do-not-disturb" is
 enabled:

--- a/makoctl
+++ b/makoctl
@@ -22,6 +22,7 @@ usage() {
 	echo "  list                           List notifications"
 	echo "  reload                         Reload the configuration file"
 	echo "  set-mode <name>                Switch the current mode"
+	echo "  mode                           List modes"
 	echo "  help                           Show this help"
 }
 
@@ -37,6 +38,13 @@ fi
 call() {
 	$BUSCTL -j --user call org.freedesktop.Notifications /fr/emersion/Mako \
 		fr.emersion.Mako -- "$@"
+}
+
+require_jq() {
+	if ! type jq >/dev/null 2>&1; then
+		echo >&2 "$0: jq is required to use this command"
+		exit 1
+	fi
 }
 
 if [ $# -eq 0 ]; then
@@ -98,10 +106,7 @@ case "$1" in
 	;;
 "menu")
 	shift 1
-	if ! type jq >/dev/null 2>&1; then
-		echo >&2 "$0: jq is required to use 'menu'"
-		exit 1
-	fi
+	require_jq
 	if [ $# -gt 1 ] && [ "$1" = "-n" ]; then
 		id="$2"
 		actions="$(call ListNotifications | jq --arg id "$id" -re '.data[0][] | select(.id.data==($id | tonumber)) | .actions.data')"
@@ -132,6 +137,10 @@ case "$1" in
 	;;
 "set-mode")
 	call SetMode "s" "$2"
+	;;
+"mode")
+	require_jq
+	call ListModes | jq -r '.data[0][]'
 	;;
 "help"|"--help"|"-h")
 	usage

--- a/makoctl
+++ b/makoctl
@@ -21,8 +21,9 @@ usage() {
 	echo "                                 notification if none is given"
 	echo "  list                           List notifications"
 	echo "  reload                         Reload the configuration file"
-	echo "  set-mode <name>                Switch the current mode"
 	echo "  mode                           List modes"
+	echo "  mode [-a mode]... [-r mode]... Add/remove modes"
+	echo "  mode -s mode...                Set modes"
 	echo "  help                           Show this help"
 }
 
@@ -135,12 +136,49 @@ case "$1" in
 "reload")
 	call Reload
 	;;
-"set-mode")
+"set-mode") # deprecated
 	call SetMode "s" "$2"
 	;;
 "mode")
+	shift 1
 	require_jq
-	call ListModes | jq -r '.data[0][]'
+	modes="$(call ListModes | jq '.data[0]')"
+	add_remove_flag=0
+	set_flag=0
+	while getopts a:r:s name; do
+		case "$name" in
+		a)
+			add_remove_flag=1
+			modes="$(echo "$modes" | jq --arg mode "$OPTARG" '. += [$mode]')"
+			;;
+		r)
+			add_remove_flag=1
+			modes="$(echo "$modes" | jq --arg mode "$OPTARG" 'del(.[] | select(. == $mode))')"
+			;;
+		s)
+			set_flag=1
+			;;
+		?)
+			exit 1
+		esac
+	done
+	if [ "$add_remove_flag" = 1 ] && [ "$set_flag" = 1 ]; then
+		echo >&2 "makoctl: -a/-r and -s cannot be used together"
+		exit 1
+	fi
+	if [ "$set_flag" = 1 ]; then
+		shift $(($OPTIND - 1))
+		modes="$(jq -n '$ARGS.positional' --args "$@")"
+	fi
+	if [ "$add_remove_flag" = 1 ] || [ "$set_flag" = 1 ]; then
+		modes="$(echo "$modes" | jq '. | unique')"
+		modes_len="$(echo "$modes" | jq '. | length')"
+		modes_args=$(echo "$modes" | jq -r '@sh')
+		# Required to behave properly when mode names contain spaces
+		eval set -- $modes_args
+		call SetModes "as" "$modes_len" "$@"
+	fi
+	echo "$modes" | jq -r '.[]'
 	;;
 "help"|"--help"|"-h")
 	usage

--- a/makoctl
+++ b/makoctl
@@ -40,8 +40,8 @@ call() {
 }
 
 if [ $# -eq 0 ]; then
-   usage
-   exit 1
+	usage
+	exit 1
 fi
 
 case "$1" in

--- a/makoctl.1.scd
+++ b/makoctl.1.scd
@@ -70,13 +70,18 @@ Sends IPC commands to the running mako daemon via dbus.
 *reload*
 	Reloads the configuration file.
 
-*set-mode* <name>
-	Switches the current mode to _name_. This replaces the previous mode.
+*mode*
+*mode* -s <mode>...
+*mode* [-a mode]... [-r mode]...
+	When run without any option, retrieves a list of current modes.
+
+	When run with the _-s_ option, replaces the current modes with the provided
+	list.
+
+	When run with the _-a_ or _-r_ options, adds or removes the provided mode
+	from the current modes.
 
 	See the _MODES_ section in **mako**(5) for more information about modes.
-
-*mode*
-	Retrieve a list of current modes.
 
 *help, -h, --help*
 	Show help message and quit.

--- a/makoctl.1.scd
+++ b/makoctl.1.scd
@@ -75,6 +75,9 @@ Sends IPC commands to the running mako daemon via dbus.
 
 	See the _MODES_ section in **mako**(5) for more information about modes.
 
+*mode*
+	Retrieve a list of current modes.
+
 *help, -h, --help*
 	Show help message and quit.
 

--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,7 @@ src_files = [
 	'dbus/mako.c',
 	'dbus/xdg.c',
 	'main.c',
+	'mode.c',
 	'notification.c',
 	'pool-buffer.c',
 	'render.c',

--- a/mode.c
+++ b/mode.c
@@ -1,0 +1,30 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdlib.h>
+#include <string.h>
+#include <wayland-util.h>
+
+#include "mako.h"
+#include "mode.h"
+
+bool has_mode(struct mako_state *state, const char *mode) {
+	const char **mode_ptr;
+	wl_array_for_each(mode_ptr, &state->current_modes) {
+		if (strcmp(*mode_ptr, mode) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void set_modes(struct mako_state *state, const char **modes, size_t modes_len) {
+	char **mode_ptr;
+	wl_array_for_each(mode_ptr, &state->current_modes) {
+		free(*mode_ptr);
+	}
+	state->current_modes.size = 0;
+
+	for (size_t i = 0; i < modes_len; i++) {
+		char **dst = wl_array_add(&state->current_modes, sizeof(char *));
+		*dst = strdup(modes[i]);
+	}
+}

--- a/mode.c
+++ b/mode.c
@@ -24,6 +24,18 @@ void set_modes(struct mako_state *state, const char **modes, size_t modes_len) {
 	state->current_modes.size = 0;
 
 	for (size_t i = 0; i < modes_len; i++) {
+		// Drop duplicate entries
+		bool dup = false;
+		for (size_t j = 0; j < i; j++) {
+			if (strcmp(modes[i], modes[j]) == 0) {
+				dup = true;
+				break;
+			}
+		}
+		if (dup) {
+			continue;
+		}
+
 		char **dst = wl_array_add(&state->current_modes, sizeof(char *));
 		*dst = strdup(modes[i]);
 	}


### PR DESCRIPTION
Supersedes #382 and #421

I tried to split the changes in separate commits to (hopefully) make the review a bit easier.

The `makoctl` implementation really stretches POSIX sh to its limits. We should consider rewriting it in C.