### PR TITLE
Move default config to installed file

### DIFF
--- a/config.in
+++ b/config.in
@@ -1,0 +1,37 @@
+width=300
+height=100
+margin=10
+padding=5
+border-size=2
+icons=@icons@
+max-icon-size=64
+font=monospace 10
+markup=1
+actions=1
+history=1
+format=<b>%s</b>\n%b
+text-alignment=left
+layer=top
+max-visible=5
+anchor=top-right
+
+on-button-left=invoke-default-action
+on-button-right=dismiss
+on-touch=dismiss
+
+max-history=5
+sort=-time
+
+# Hide grouped notifications by default, and put the group count in
+# their format...
+[grouped]
+invisible=1
+format=(%g) <b>%s</b>\n%b
+
+# ...but make the first one in the group visible.
+[group_index=0]
+invisible=0
+
+# Define the default format for the hidden placeholder notification.
+[hidden]
+format=(%h more)

--- a/include/config.h
+++ b/include/config.h
@@ -109,10 +109,8 @@ struct mako_config {
 	struct mako_style superstyle;
 };
 
-void init_default_config(struct mako_config *config);
 void finish_config(struct mako_config *config);
 
-void init_default_style(struct mako_style *style);
 void init_empty_style(struct mako_style *style);
 void finish_style(struct mako_style *style);
 bool apply_style(struct mako_style *target, const struct mako_style *style);

--- a/include/config.h
+++ b/include/config.h
@@ -120,7 +120,6 @@ bool apply_superset_style(
 		struct mako_style *target, struct mako_config *config);
 
 int parse_config_arguments(struct mako_config *config, int argc, char **argv);
-int load_config_file(struct mako_config *config, char *config_arg);
 int reload_config(struct mako_config *config, int argc, char **argv);
 bool apply_global_option(struct mako_config *config, const char *name,
 	const char *value);

--- a/main.c
+++ b/main.c
@@ -107,14 +107,10 @@ int main(int argc, char *argv[]) {
 	wl_list_init(&state.surfaces);
 
 	// This is a bit wasteful, but easier than special-casing the reload.
-	init_default_config(&state.config);
 	int ret = reload_config(&state.config, argc, argv);
-
 	if (ret < 0) {
-		finish_config(&state.config);
 		return EXIT_FAILURE;
 	} else if (ret > 0) {
-		finish_config(&state.config);
 		printf("%s", usage);
 		return EXIT_SUCCESS;
 	}

--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,8 @@ if (not cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>') or
 	epoll = dependency('epoll-shim')
 endif
 
+add_project_arguments('-DSYSCONFDIR="@0@"'.format(get_option('sysconfdir')), language: 'c')
+
 if get_option('sd-bus-provider') == 'auto'
 	assert(get_option('auto_features').auto(), 'sd-bus-provider must not be set to auto since auto_features != auto')
 	sdbus = dependency('libsystemd', 'libelogind', 'basu')
@@ -105,12 +107,20 @@ install_data(
 
 conf_data = configuration_data()
 conf_data.set('bindir', get_option('prefix') / get_option('bindir'))
+conf_data.set('icons', gdk_pixbuf.found().to_int())
 
 configure_file(
 	configuration: conf_data,
 	input: 'fr.emersion.mako.service.in',
 	output: '@BASENAME@',
 	install_dir: get_option('datadir') + '/dbus-1/services',
+)
+
+configure_file(
+	configuration: conf_data,
+	input: 'config.in',
+	output: '@BASENAME@',
+	install_dir: get_option('sysconfdir') + '/mako/config',
 )
 
 scdoc = dependency('scdoc', required: get_option('man-pages'), version: '>= 1.9.7', native: true)


### PR DESCRIPTION
- [ ] This doesn't work well during development: `/etc/mako/config` is used as defaults, the user-provided config/flags are loaded on top, but `/etc/mako/config` might not be installed in which case mako won't run at all.
- [ ] Write docs