### PR TITLE
Allow rendering notification_id in notifications

### DIFF
--- a/mako.5.scd
+++ b/mako.5.scd
@@ -413,6 +413,8 @@ specifiers.
 
 *%g*	Number of notifications in the current group
 
+*%i*	Notification id
+
 ## For the hidden notifications placeholder
 
 *%h*	Number of hidden notifications

--- a/notification.c
+++ b/notification.c
@@ -265,6 +265,8 @@ char *format_notif_text(char variable, bool *markup, void *data) {
 	switch (variable) {
 	case 'a':
 		return strdup(notif->app_name);
+	case 'i':
+		return mako_asprintf("%d", notif->id);
 	case 's':
 		return strdup(notif->summary);
 	case 'b':

--- a/types.c
+++ b/types.c
@@ -14,7 +14,7 @@
 #include "types.h"
 
 
-const char VALID_FORMAT_SPECIFIERS[] = "%asbhtg";
+const char VALID_FORMAT_SPECIFIERS[] = "%asbhtgi";
 
 
 bool parse_boolean(const char *string, bool *out) {


### PR DESCRIPTION
New format specifier is `%i`. I tested this with adding this to my
config:

     [actionable=true]
     format=<b>%s</b> [%i]\n%b