### PR TITLE
Add app-name pattern matching

### DIFF
--- a/include/criteria.h
+++ b/include/criteria.h
@@ -22,6 +22,7 @@ struct mako_criteria {
 
 	// Fields that can be matched:
 	char *app_name;
+	regex_t app_name_pattern;
 	char *app_icon;
 	bool actionable;  // Whether mako_notification.actions is nonempty
 	bool expiring;  // Whether mako_notification.requested_timeout is non-zero

--- a/include/types.h
+++ b/include/types.h
@@ -44,6 +44,7 @@ bool parse_directional(const char *string, struct mako_directional *out);
 // notifications to group with each other.
 struct mako_criteria_spec {
 	bool app_name;
+	bool app_name_pattern;
 	bool app_icon;
 	bool actionable;
 	bool expiring;

--- a/types.c
+++ b/types.c
@@ -238,6 +238,7 @@ bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out) {
 bool mako_criteria_spec_any(const struct mako_criteria_spec *spec) {
 	return
 		spec->app_name ||
+		spec->app_name_pattern ||
 		spec->app_icon ||
 		spec->actionable ||
 		spec->expiring ||


### PR DESCRIPTION
Needed for apps (like Telegram) that add a notification count to their window title, making exact matching fail.