### PR TITLE
fix segfault when surface->surface_output is NULL

### DIFF
--- a/wayland.c
+++ b/wayland.c
@@ -229,6 +229,9 @@ static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
 
 	struct mako_surface *surface;
 	wl_list_for_each(surface, &state->surfaces, link) {
+		if (!surface->surface_output) {
+			continue;
+		}
 		if (surface->surface_output->scale > scale) {
 			scale = surface->surface_output->scale;
 		}


### PR DESCRIPTION
Just adds a check to make sure `surface_output` is not NULL

I believe this fixes https://github.com/emersion/mako/issues/441 and https://github.com/emersion/mako/issues/440

Feedback is appreciated