### PR TITLE
makoctl: add command to list history

### DIFF
--- a/contrib/completions/bash/makoctl
+++ b/contrib/completions/bash/makoctl
@@ -11,6 +11,7 @@ _makoctl()
     'invoke'
     'menu'
     'list'
+    'history'
     'reload'
     'set-mode'
     'help'

--- a/contrib/completions/fish/makoctl.fish
+++ b/contrib/completions/fish/makoctl.fish
@@ -12,6 +12,7 @@ complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a restore -d 'Re
 complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a invoke -d 'Invoke an action on the notification (the last one if none is given)' -x
 complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a menu -d 'Use a program to select one action to be invoked on the notification (the last one if none is given)' -x
 complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a list -d 'List notifications' -x
+complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a history -d 'List history' -x
 complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a reload -d 'Reload the configuration file' -x
 complete -c makoctl -n '__fish_makoctl_complete_no_subcommand' -a help -d 'Show help message and quit' -x
 

--- a/contrib/completions/zsh/_makoctl
+++ b/contrib/completions/zsh/_makoctl
@@ -7,6 +7,7 @@ makoctl_cmds=(
 	'restore:Restore the most recently expired notification from the history buffer'
 	'invoke:Invoke an action on the first notification. If action is not specified, invoke the default action'
 	'list:Retrieve a list of current notifications'
+	'history:Retrieve a list of dismissed notifications'
 	'reload:Reload the configuration file'
 	'help:Show help message and quit'
 )

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -140,9 +140,7 @@ done:
 	return sd_bus_reply_method_return(msg, "");
 }
 
-static int handle_list_notifications(sd_bus_message *msg, void *data,
-		sd_bus_error *ret_error) {
-	struct mako_state *state = data;
+static int handle_list(sd_bus_message *msg, struct wl_list *list) {
 
 	sd_bus_message *reply = NULL;
 	int ret = sd_bus_message_new_method_return(msg, &reply);
@@ -156,7 +154,7 @@ static int handle_list_notifications(sd_bus_message *msg, void *data,
 	}
 
 	struct mako_notification *notif;
-	wl_list_for_each(notif, &state->notifications, link) {
+	wl_list_for_each(notif, list, link) {
 		ret = sd_bus_message_open_container(reply, 'a', "{sv}");
 		if (ret < 0) {
 			return ret;
@@ -265,6 +263,18 @@ static int handle_list_notifications(sd_bus_message *msg, void *data,
 
 	sd_bus_message_unref(reply);
 	return 0;
+}
+
+static int handle_list_notifications(sd_bus_message *msg, void *data,
+		sd_bus_error *ret_error) {
+	struct mako_state *state = data;
+	return handle_list(msg, &state->notifications);
+}
+
+static int handle_list_history(sd_bus_message *msg, void *data,
+		sd_bus_error *ret_error) {
+	struct mako_state *state = data;
+	return handle_list(msg, &state->history);
 }
 
 /**
@@ -428,6 +438,7 @@ static const sd_bus_vtable service_vtable[] = {
 	SD_BUS_METHOD("InvokeAction", "us", "", handle_invoke_action, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("RestoreNotification", "", "", handle_restore_action, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("ListNotifications", "", "aa{sv}", handle_list_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("ListHistory", "", "aa{sv}", handle_list_history, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("Reload", "", "", handle_reload, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("SetMode", "s", "", handle_set_mode, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("ListModes", "", "as", handle_list_modes, SD_BUS_VTABLE_UNPRIVILEGED),

--- a/makoctl
+++ b/makoctl
@@ -20,6 +20,7 @@ usage() {
 	echo "                                 with the given id, or the last"
 	echo "                                 notification if none is given"
 	echo "  list                           List notifications"
+	echo "  history                        List history"
 	echo "  reload                         Reload the configuration file"
 	echo "  mode                           List modes"
 	echo "  mode [-a mode]... [-r mode]... Add/remove modes"
@@ -132,6 +133,9 @@ case "$1" in
 	;;
 "list")
 	call ListNotifications
+	;;
+"history")
+	call ListHistory
 	;;
 "reload")
 	call Reload

--- a/makoctl.1.scd
+++ b/makoctl.1.scd
@@ -67,6 +67,9 @@ Sends IPC commands to the running mako daemon via dbus.
 *list*
 	Retrieve a list of current notifications.
 
+*history*
+	Retrieve a list of dismissed notifications.
+
 *reload*
 	Reloads the configuration file.
 


### PR DESCRIPTION
Implements `makoctl history` discussed in #91.
Extends #220 by listing the history buffer with `makoctl history`in the same format as `makoctl list`. I put the code from `dbus/mako.c:handle_list_notifications` into  `dbus/mako.c:handle_list` and made the list given to `wl_list_for_each` an argument. `handle_list`is than used by `handle_list_notification` with `mako_state->notifications` and by `handle_list_history` with `mako_state->history`. A short test was successful, but I should note that I have no experience with dbus.