### PR TITLE
Fix positioning of icon and text

### DIFF
--- a/render.c
+++ b/render.c
@@ -294,9 +294,9 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 	}
 
 	if (icon_vertical) {
-		text_x = (notif_width - text_width) / 2;
+		text_x = (notif_width - text_width - border_size) / 2;
 	} else {
-		text_y = (notif_height - text_height) / 2;
+		text_y = (notif_height - text_height - border_size) / 2;
 	}
 
 	// Render text

--- a/render.c
+++ b/render.c
@@ -271,21 +271,23 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 		switch (style->icon_location) {
 		case MAKO_ICON_LOCATION_LEFT:
 			xpos = offset_x + style->border_size +
-				(text_x - icon->width) / 2;
+				style->padding.left;
 			ypos = ypos_center;
 			break;
 		case MAKO_ICON_LOCATION_RIGHT:
 			xpos = offset_x + notif_width - style->border_size -
-				icon->width - style->margin.right;
+				style->padding.right - icon->width;
 			ypos = ypos_center;
 			break;
 		case MAKO_ICON_LOCATION_TOP:
 			xpos = xpos_center;
-			ypos = offset_y + style->border_size;
+			ypos = offset_y + style->border_size +
+				style->padding.top;
 			break;
 		case MAKO_ICON_LOCATION_BOTTOM:
 			xpos = xpos_center;
-			ypos = offset_y + text_y + text_height + style->margin.bottom;
+			ypos = offset_y + notif_height - style->border_size -
+				style->padding.bottom - icon->height;
 			break;
 		}
 		draw_icon(cairo, icon, xpos, ypos, scale);


### PR DESCRIPTION
This PR fixes two things:
- The positioning of the icon &mdash; see the commit message for more information
- The positioning of the text, which was offset by the size of the border, either along the x-asis or y-axis depending on whether the icon is positioned top/bottom or left/right. This should fix #329.