### PR TITLE
Add urgency indicator in makoctl list.

### DIFF
--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -202,6 +202,12 @@ static int handle_list(sd_bus_message *msg, struct wl_list *list) {
 			return ret;
 		}
 
+		ret = sd_bus_message_append(reply, "{sv}", "urgency",
+			"y", notif->urgency);
+		if (ret < 0) {
+			return ret;
+		}
+
 		ret = sd_bus_message_open_container(reply, 'e', "sv");
 		if (ret < 0) {
 			return ret;


### PR DESCRIPTION

Adds a new `urgency` field for each notification in the `makoctl list` output.

The value returned is `0` for `Low`, `1` for `Normal`, and `2` for `Critical`, same as the spec.

An example output for `notify-send -u critical 'The house is on fire!'`:
```json
{
        "type" : "aa{sv}",
        "data" : [
                [
                        {
                                "app-name" : {
                                        "type" : "s",
                                        "data" : "notify-send"
                                },
                                "app-icon" : {
                                        "type" : "s",
                                        "data" : ""
                                },
                                "category" : {
                                        "type" : "s",
                                        "data" : ""
                                },
                                "desktop-entry" : {
                                        "type" : "s",
                                        "data" : ""
                                },
                                "summary" : {
                                        "type" : "s",
                                        "data" : "The house is on fire!"
                                },
                                "body" : {
                                        "type" : "s",
                                        "data" : ""
                                },
                                "id" : {
                                        "type" : "u",
                                        "data" : 1
                                },
                                "urgency" : {
                                        "type" : "y",
                                        "data" : 2
                                },
                                "actions" : {
                                        "type" : "a{ss}",
                                        "data" : {}
                                }
                        }
                ]
        ]
}
```

Closes #446 
