### PR TITLE
Add `invoke-action <action>`

### DIFF
--- a/config.c
+++ b/config.c
@@ -126,7 +126,8 @@ void init_default_style(struct mako_style *style) {
 	style->anchor =
 		ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
 
-	style->button_bindings.left.action = MAKO_BINDING_INVOKE_DEFAULT_ACTION;
+	style->button_bindings.left.action = MAKO_BINDING_INVOKE_ACTION;
+	style->button_bindings.left.action_name = strdup(DEFAULT_ACTION_KEY);
 	style->button_bindings.right.action = MAKO_BINDING_DISMISS;
 	style->button_bindings.middle.action = MAKO_BINDING_NONE;
 	style->touch_binding.action = MAKO_BINDING_DISMISS;
@@ -141,6 +142,7 @@ void init_empty_style(struct mako_style *style) {
 
 static void finish_binding(struct mako_binding *binding) {
 	free(binding->command);
+	free(binding->action_name);
 }
 
 void finish_style(struct mako_style *style) {
@@ -162,6 +164,9 @@ static void copy_binding(struct mako_binding *dst,
 	*dst = *src;
 	if (src->command != NULL) {
 		dst->command = strdup(src->command);
+	}
+	if (src->action_name != NULL) {
+		dst->action_name = strdup(src->action_name);
 	}
 }
 
@@ -646,7 +651,11 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		} else if (strcmp(value, "dismiss-group") == 0) {
 			binding.action = MAKO_BINDING_DISMISS_GROUP;
 		} else if (strcmp(value, "invoke-default-action") == 0) {
-			binding.action = MAKO_BINDING_INVOKE_DEFAULT_ACTION;
+			binding.action = MAKO_BINDING_INVOKE_ACTION;
+			binding.action_name = strdup(DEFAULT_ACTION_KEY);
+		} else if (has_prefix(value, "invoke-action ")) {
+			binding.action = MAKO_BINDING_INVOKE_ACTION;
+			binding.action_name = strdup(value + strlen("invoke-action "));
 		} else if (has_prefix(value, "exec ")) {
 			binding.action = MAKO_BINDING_EXEC;
 			binding.command = strdup(value + strlen("exec "));

--- a/include/config.h
+++ b/include/config.h
@@ -12,13 +12,14 @@ enum mako_binding_action {
 	MAKO_BINDING_DISMISS,
 	MAKO_BINDING_DISMISS_GROUP,
 	MAKO_BINDING_DISMISS_ALL,
-	MAKO_BINDING_INVOKE_DEFAULT_ACTION,
+	MAKO_BINDING_INVOKE_ACTION,
 	MAKO_BINDING_EXEC,
 };
 
 struct mako_binding {
 	enum mako_binding_action action;
-	char *command; // for MAKO_BINDING_EXEC
+	char *command;     // for MAKO_BINDING_EXEC
+	char *action_name; // for MAKO_BINDING_INVOKE_ACTION
 };
 
 enum mako_sort_criteria {
@@ -108,6 +109,8 @@ struct mako_config {
 
 	struct mako_style superstyle;
 };
+
+#define DEFAULT_ACTION_KEY "default"
 
 void init_default_config(struct mako_config *config);
 void finish_config(struct mako_config *config);

--- a/include/notification.h
+++ b/include/notification.h
@@ -76,8 +76,6 @@ struct mako_binding_context {
 	uint32_t serial;
 };
 
-#define DEFAULT_ACTION_KEY "default"
-
 typedef char *(*mako_format_func_t)(char variable, bool *markup, void *data);
 
 bool hotspot_at(struct mako_hotspot *hotspot, int32_t x, int32_t y);

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -33,7 +33,7 @@ Empty lines and lines that begin with # are ignored.
 
 Bindings allow one to perform an action when an event is triggered. Supported
 values are _none_, _dismiss_, _dismiss-all_, _dismiss-group_,
-_invoke-default-action_ and _exec <command>_.
+_invoke-action <action>_, _invoke-default-action_ and _exec <command>_.
 
 *on-button-left*=_action_
 	Default: invoke-default-action
@@ -62,6 +62,16 @@ The following option will play a sound when a new notification is opened:
 
 ```
 on-notify=exec mpv /usr/share/sounds/freedesktop/stereo/message.oga
+```
+
+When using _invoke-action_ or _invoke-default-action_ a xdg-activation
+token will be sent to the client, allowing the client to request focus
+from the compositor. The compositor must support the xdg_activation_v1
+protocol and allow the focus request for the example to work correctly:
+
+```
+[app-name="some-app-id" actionable]
+on-button-left=invoke-action mail-reply-sender
 ```
 
 # STYLE OPTIONS


### PR DESCRIPTION
Before this patch, it was impossible to send a different action
than `default` when clicking on a notification without loosing
access to the surface and thus the xdg_activation token.

With this patch, the user is now able to configure the action
to be sent when clicking on the notification while preserving
access to the xdg_activation token.

Example configuration:
```ini
[app-name="some-app-id" actionable]
on-button-left=invoke-action mail-reply-sender