### PR TITLE
mako.5.scd: enhance the use of mpv

### DIFF
--- a/mako.5.scd
+++ b/mako.5.scd
@@ -61,7 +61,7 @@ on-button-middle=exec makoctl menu -n "$id" dmenu -p 'Select action: '
 The following option will play a sound when a new notification is opened:
 
 ```
-on-notify=exec mpv /usr/share/sounds/freedesktop/stereo/message.oga
+on-notify=exec mpv --keep-open=no /usr/share/sounds/freedesktop/stereo/message.oga
 ```
 
 When using _invoke-action_ or _invoke-default-action_ a xdg-activation


### PR DESCRIPTION
Add the mpv --keep-open=no option to prevent too many connections to the pulseaudio audio server. That case occurs where user has keep-open=yes in their mpv configuration. Each mpv occurrence will stay logged to the pulseaudio server, and prevent a new connection once 64 clients connected.

The --keep-open=no option allows to close the mpv option once the sound played.