### PR TITLE
use last_scale initially to avoid many redraws (which cause flickering)

### DIFF
--- a/include/mako.h
+++ b/include/mako.h
@@ -75,6 +75,7 @@ struct mako_state {
 	struct wl_list notifications; // mako_notification::link
 	struct wl_list history; // mako_notification::link
 	struct wl_array current_modes; // char *
+	uint32_t last_scale;
 
 	int argc;
 	char **argv;

--- a/main.c
+++ b/main.c
@@ -76,6 +76,7 @@ static bool init(struct mako_state *state) {
 	wl_array_init(&state->current_modes);
 	const char *mode = "default";
 	set_modes(state, &mode, 1);
+	state->last_scale = 1;
 	return true;
 }
 

--- a/wayland.c
+++ b/wayland.c
@@ -624,9 +624,10 @@ static void send_frame(struct mako_surface *surface) {
 		return;
 	}
 
-	int scale = 1;
+	int scale = state->last_scale;
 	if (surface->surface_output != NULL) {
 		scale = surface->surface_output->scale;
+		state->last_scale = scale;
 	}
 
 	surface->current_buffer =


### PR DESCRIPTION
## The problem

mako appears with scale=1, and finds the output prefers scale=2, so it redraws with scale=2. This makes the window reshapes (supposingly because pango redraws with higher dpi and the rounding is different). So every time it appears, it flickers once.

## Proposed solution

Remember last scale because it's very likely that the next time a notification is shown it's on the same output, thus avoiding above flickering in this case.