### PR TITLE
Use systemd to check environment variable

### DIFF
--- a/contrib/systemd/mako.service
+++ b/contrib/systemd/mako.service
@@ -3,11 +3,11 @@ Description=Lightweight Wayland notification daemon
 Documentation=man:mako(1)
 PartOf=graphical-session.target
 After=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
 
 [Service]
 Type=dbus
 BusName=org.freedesktop.Notifications
-ExecCondition=/bin/sh -c '[ -n "$WAYLAND_DISPLAY" ]'
 ExecStart=/usr/bin/mako
 ExecReload=/usr/bin/makoctl reload
 


### PR DESCRIPTION
Unit files have a built-in condition to check variables, so let's use it instead of executing a shell command.