### PR TITLE
--version (-v) command line argument

### DIFF
--- a/config.c
+++ b/config.c
@@ -834,7 +834,8 @@ int load_config_file(struct mako_config *config, char *config_arg) {
 }
 
 enum mako_parse_args_status
-parse_config_arguments(struct mako_config *config, int argc, char **argv) {
+	parse_config_arguments(struct mako_config *config, int argc, char **argv) {
+
 	static const struct option long_options[] = {
 		{"help", no_argument, 0, 'h'},
 		{"version", no_argument, 0, 'v'},

--- a/include/config.h
+++ b/include/config.h
@@ -7,6 +7,13 @@
 #include <pango/pango.h>
 #include "types.h"
 
+enum mako_parse_args_status {
+	MAKO_ARGS_FAILURE = -1,
+	MAKO_ARGS_SUCCESS = 0,
+	MAKO_ARGS_SHOW_HELP,
+	MAKO_ARGS_SHOW_VERSION
+};
+
 enum mako_binding_action {
 	MAKO_BINDING_NONE,
 	MAKO_BINDING_DISMISS,

--- a/include/config.h
+++ b/include/config.h
@@ -129,7 +129,8 @@ bool apply_style(struct mako_style *target, const struct mako_style *style);
 bool apply_superset_style(
 		struct mako_style *target, struct mako_config *config);
 
-int parse_config_arguments(struct mako_config *config, int argc, char **argv);
+enum mako_parse_args_status
+	parse_config_arguments(struct mako_config *config, int argc, char **argv);
 int load_config_file(struct mako_config *config, char *config_arg);
 int reload_config(struct mako_config *config, int argc, char **argv);
 bool apply_global_option(struct mako_config *config, const char *name,

--- a/main.c
+++ b/main.c
@@ -17,6 +17,7 @@ static const char usage[] =
 	"Usage: mako [options...]\n"
 	"\n"
 	"  -h, --help                          Show help message and quit.\n"
+	"  -v, --version                       Show mako's version and quit.\n"
 	"  -c, --config <path>                 Path to config file.\n"
 	"      --font <font>                   Font family and size.\n"
 	"      --background-color <color>      Background color.\n"
@@ -117,12 +118,16 @@ int main(int argc, char *argv[]) {
 	init_default_config(&state.config);
 	int ret = reload_config(&state.config, argc, argv);
 
-	if (ret < 0) {
+	if (ret == MAKO_ARGS_FAILURE) {
 		finish_config(&state.config);
 		return EXIT_FAILURE;
-	} else if (ret > 0) {
+	} else if (ret == MAKO_ARGS_SHOW_HELP) {
 		finish_config(&state.config);
 		printf("%s", usage);
+		return EXIT_SUCCESS;
+	} else if (ret == MAKO_ARGS_SHOW_VERSION) {
+		finish_config(&state.config);
+		printf("mako %s\n", MAKO_VERSION);
 		return EXIT_SUCCESS;
 	}
 

--- a/mako.1.scd
+++ b/mako.1.scd
@@ -19,6 +19,9 @@ dismissed with a click or via *makoctl*(1).
 *-h, --help*
 	Show help message and quit.
 
+*-v, --version*
+	Show mako's version message and quit.
+
 *-c, --config*
 	Custom path to the config file.
 

--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,8 @@ if gdk_pixbuf.found()
 	add_global_arguments('-DHAVE_ICONS=1', language: 'c')
 endif
 
+add_project_arguments('-DMAKO_VERSION="@0@"'.format(meson.project_version()), language: 'c')
+
 subdir('contrib/completions')
 subdir('protocol')
 


### PR DESCRIPTION
Added a `--version` (`-v`) command line argument that uses the version information from meson. The return type of `parse_config_arguments` was changed to a new custom enum, for a better description of return values and possible future additions.