### PR TITLE
Hints: Support 'sound-file' and 'sound-name' hints in makoctl list

### DIFF
--- a/criteria.c
+++ b/criteria.c
@@ -35,6 +35,7 @@ void destroy_criteria(struct mako_criteria *criteria) {
 	free(criteria->app_icon);
 	free(criteria->category);
 	free(criteria->desktop_entry);
+	free(criteria->sound_name);
 	free(criteria->summary);
 	regfree(&criteria->summary_pattern);
 	free(criteria->body);
@@ -105,6 +106,11 @@ bool match_criteria(struct mako_criteria *criteria,
 
 	if (spec.desktop_entry &&
 			strcmp(criteria->desktop_entry, notif->desktop_entry) != 0) {
+		return false;
+	}
+
+	if (spec.sound_name &&
+			strcmp(criteria->sound_name, notif->sound_name) != 0) {
 		return false;
 	}
 
@@ -325,6 +331,10 @@ bool apply_criteria_field(struct mako_criteria *criteria, char *token) {
 				return false;
 			}
 			criteria->spec.group_index = true;
+			return true;
+		} else if (strcmp(key, "sound-name") == 0) {
+			criteria->sound_name = strdup(value);
+			criteria->spec.sound_name = true;
 			return true;
 		} else if (strcmp(key, "summary") == 0) {
 			criteria->summary = strdup(value);

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -208,6 +208,12 @@ static int handle_list(sd_bus_message *msg, struct wl_list *list) {
 			return ret;
 		}
 
+		ret = sd_bus_message_append(reply, "{sv}", "sound-file",
+			"s", notif->sound_file);
+		if (ret < 0) {
+			return ret;
+		}
+
 		ret = sd_bus_message_open_container(reply, 'e', "sv");
 		if (ret < 0) {
 			return ret;

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -214,6 +214,12 @@ static int handle_list(sd_bus_message *msg, struct wl_list *list) {
 			return ret;
 		}
 
+		ret = sd_bus_message_append(reply, "{sv}", "sound-name",
+			"s", notif->sound_name);
+		if (ret < 0) {
+			return ret;
+		}
+
 		ret = sd_bus_message_open_container(reply, 'e', "sv");
 		if (ret < 0) {
 			return ret;

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -229,6 +229,14 @@ static int handle_notify(sd_bus_message *msg, void *data,
 			}
 			free(notif->desktop_entry);
 			notif->desktop_entry = strdup(desktop_entry);
+		} else if (strcmp(hint, "sound-file") == 0) {
+			const char *sound_file = NULL;
+			ret = sd_bus_message_read(msg, "v", "s", &sound_file);
+			if (ret < 0) {
+				return ret;
+			}
+			free(notif->sound_file);
+			notif->sound_file = strdup(sound_file);
 		} else if (strcmp(hint, "value") == 0) {
 			int32_t progress = 0;
 			ret = sd_bus_message_read(msg, "v", "i", &progress);

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -237,6 +237,14 @@ static int handle_notify(sd_bus_message *msg, void *data,
 			}
 			free(notif->sound_file);
 			notif->sound_file = strdup(sound_file);
+		} else if (strcmp(hint, "sound-name") == 0) {
+			const char *sound_name = NULL;
+			ret = sd_bus_message_read(msg, "v", "s", &sound_name);
+			if (ret < 0) {
+				return ret;
+			}
+			free(notif->sound_name);
+			notif->sound_name = strdup(sound_name);
 		} else if (strcmp(hint, "value") == 0) {
 			int32_t progress = 0;
 			ret = sd_bus_message_read(msg, "v", "i", &progress);

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -28,6 +28,7 @@ struct mako_criteria {
 	enum mako_notification_urgency urgency;
 	char *category;
 	char *desktop_entry;
+	char *sound_name;
 	char *summary;
 	regex_t summary_pattern;
 	char *body;

--- a/include/notification.h
+++ b/include/notification.h
@@ -35,6 +35,7 @@ struct mako_notification {
 	char *app_name;
 	char *app_icon;
 	char *sound_file;
+	char *sound_name;
 	char *summary;
 	char *body;
 	int32_t requested_timeout;

--- a/include/notification.h
+++ b/include/notification.h
@@ -34,6 +34,7 @@ struct mako_notification {
 
 	char *app_name;
 	char *app_icon;
+	char *sound_file;
 	char *summary;
 	char *body;
 	int32_t requested_timeout;

--- a/include/types.h
+++ b/include/types.h
@@ -50,6 +50,7 @@ struct mako_criteria_spec {
 	bool urgency;
 	bool category;
 	bool desktop_entry;
+	bool sound_name;
 	bool summary;
 	bool summary_pattern;
 	bool body;

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -303,6 +303,7 @@ The following fields are available in criteria:
 - _urgency_ (one of "low", "normal", "critical")
 - _category_ (string)
 - _desktop-entry_ (string)
+- _sound-name_ (string)
 - _actionable_ (boolean)
 - _expiring_ (boolean)
 - _mode_ (string)

--- a/notification.c
+++ b/notification.c
@@ -46,6 +46,7 @@ void reset_notification(struct mako_notification *notif) {
 	free(notif->app_name);
 	free(notif->app_icon);
 	free(notif->sound_file);
+	free(notif->sound_name);
 	free(notif->summary);
 	free(notif->body);
 	free(notif->category);
@@ -59,6 +60,7 @@ void reset_notification(struct mako_notification *notif) {
 	notif->app_name = strdup("");
 	notif->app_icon = strdup("");
 	notif->sound_file = strdup("");
+	notif->sound_name = strdup("");
 	notif->summary = strdup("");
 	notif->body = strdup("");
 	notif->category = strdup("");
@@ -100,6 +102,7 @@ void destroy_notification(struct mako_notification *notif) {
 	free(notif->app_name);
 	free(notif->app_icon);
 	free(notif->sound_file);
+	free(notif->sound_name);
 	free(notif->summary);
 	free(notif->body);
 	free(notif->category);

--- a/notification.c
+++ b/notification.c
@@ -45,6 +45,7 @@ void reset_notification(struct mako_notification *notif) {
 
 	free(notif->app_name);
 	free(notif->app_icon);
+	free(notif->sound_file);
 	free(notif->summary);
 	free(notif->body);
 	free(notif->category);
@@ -57,6 +58,7 @@ void reset_notification(struct mako_notification *notif) {
 
 	notif->app_name = strdup("");
 	notif->app_icon = strdup("");
+	notif->sound_file = strdup("");
 	notif->summary = strdup("");
 	notif->body = strdup("");
 	notif->category = strdup("");
@@ -97,6 +99,7 @@ void destroy_notification(struct mako_notification *notif) {
 
 	free(notif->app_name);
 	free(notif->app_icon);
+	free(notif->sound_file);
 	free(notif->summary);
 	free(notif->body);
 	free(notif->category);

--- a/types.c
+++ b/types.c
@@ -204,6 +204,8 @@ bool parse_criteria_spec(const char *string, struct mako_criteria_spec *out) {
 			out->category = true;
 		} else if (strcmp(token, "desktop-entry") == 0) {
 			out->desktop_entry = true;
+		} else if (strcmp(token, "sound-name") == 0) {
+			out->sound_name = true;
 		} else if (strcmp(token, "summary") == 0) {
 			out->summary = true;
 		} else if (strcmp(token, "body") == 0) {


### PR DESCRIPTION
Reference: https://specifications.freedesktop.org/notification-spec/latest/ar01s08.html

Added sound-file and sound-name to the data so they'll appear in makoctl list. Also added a criteria for sound-name.

You can use this config to play the sounds:

```
# Play a sound file when it exists and on-notify isn't overridden
on-notify=exec mpv --really-quiet "$(makoctl list | jq -r '.data[0][0]."sound-file".data')"


# Ring until you click or tap on it
[sound-name="phone-incoming-call"]
on-notify=exec mpv --really-quiet --loop /usr/share/sounds/freedesktop/stereo/phone-incoming-call.oga
on-button-left=exec pkill -9 -f 'mpv .*phone-incoming-call.oga'
on-touch=exec pkill -9 -f 'mpv .*phone-incoming-call.oga'

# Specify any of the sounds you want to hear
[sound-name="message-new-instant"]
on-notify=exec mpv --really-quiet /usr/share/sounds/freedesktop/stereo/message-new-instant.oga
[sound-name="message-new-email"]
on-notify=exec mpv --really-quiet /usr/share/sounds/freedesktop/stereo/message-new-email.oga
```

Closes #424

Testing notes:

```sh
# sound-file hint
notify-send "Where am I?" -h STRING:sound-file:/usr/share/sounds/freedesktop/stereo/audio-channel-front-right.oga
makoctl list | jq -r '.data[0][0]."sound-file".data'
# sound-name hint
notify-send "Click to silence" -h STRING:sound-name:phone-incoming-call
makoctl list | jq -r '.data[0][0]."sound-name".data'
```

