### PR TITLE
readme: basu needs a manual dbus user session

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ explicitly start this one. Some ways of achieving this is:
 - If you're using Sway you can start mako on launch by putting `exec mako` in
   your configuration file.
 
-- If you are using elogind, you might need to manually start a dbus user
+- If you are not using systemd, you might need to manually start a dbus user
   session: `dbus-daemon --session --address=unix:path=$XDG_RUNTIME_DIR/bus`
 
 ## Configuration


### PR DESCRIPTION
A manually started dbus user session is not only needed for elogind, but for basu too. In other words, any environment not using systemd might need it.

It took me a while to figure this out on my FreeBSD box.

As I am not a native speaker, feel free to correct any mistakes I made in wording or grammar.