### PR TITLE
Use explicit raw JSON from busctl

### DIFF
--- a/makoctl
+++ b/makoctl
@@ -39,7 +39,7 @@ if ! type $BUSCTL >/dev/null 2>&1; then
 fi
 
 call() {
-	$BUSCTL -j --user call org.freedesktop.Notifications /fr/emersion/Mako \
+	$BUSCTL --json=short --user call org.freedesktop.Notifications /fr/emersion/Mako \
 		fr.emersion.Mako -- "$@"
 }
 


### PR DESCRIPTION
Some time ago `makoctl mode` mysteriously stopped working for me with a `jq` error that seemed to indicate bad JSON content. I finally took some time to debug it and it was because I had set `SYSTEMD_COLORS=16` for my user. The `-j` flag on `busctl` appears to be sensitive to this. Changing it to `--json=short` will ensure the output of that command is always raw.

```
$ SYSTEMD_COLORS=16 busctl -j --user call org.freedesktop.Notifications /fr/emersion/Mako fr.emersion.Mako -- ListModes | jq '.data[0]'
jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 1, column 18
```

```
$ SYSTEMD_COLORS=16 busctl --json=short --user call org.freedesktop.Notifications /fr/emersion/Mako fr.emersion.Mako -- ListModes | jq '.data[0]'
[
  "default"
]
```