### PR TITLE
Avoid invalid frame callbacks

### DIFF
--- a/surface.c
+++ b/surface.c
@@ -12,6 +12,9 @@ void destroy_surface(struct mako_surface *surface) {
 	if (surface->surface != NULL) {
 		wl_surface_destroy(surface->surface);
 	}
+	if (surface->frame_callback != NULL) {
+		wl_callback_destroy(surface->frame_callback);
+	}
 	finish_buffer(&surface->buffers[0]);
 	finish_buffer(&surface->buffers[1]);
 

--- a/wayland.c
+++ b/wayland.c
@@ -720,8 +720,10 @@ static void frame_handle_done(void *data, struct wl_callback *callback,
 		uint32_t time) {
 	struct mako_surface *surface = data;
 
-	wl_callback_destroy(surface->frame_callback);
-	surface->frame_callback = NULL;
+	if (surface->frame_callback) {
+		wl_callback_destroy(surface->frame_callback);
+		surface->frame_callback = NULL;
+	}
 
 	// Only draw again if we need to
 	if (surface->dirty) {


### PR DESCRIPTION
`surface->frame_callback` could have already been destroyed in `layer_surface_handle_closed`, and calling `wl_callback_destory` with NULL segfaults.

Also, the frame callback should be destroyed in `destroy_surface`, otherwise the surface can be used in the callback after being freed.

Fixes #493.