### PR TITLE
Extend --no-history functionality

### DIFF
--- a/config.c
+++ b/config.c
@@ -149,6 +149,7 @@ void finish_style(struct mako_style *style) {
 	finish_binding(&style->button_bindings.right);
 	finish_binding(&style->touch_binding);
 	finish_binding(&style->notify_binding);
+	finish_binding(&style->timeout_binding);
 	free(style->icon_path);
 	free(style->font);
 	free(style->format);
@@ -388,6 +389,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 	if (style->spec.notify_binding) {
 		copy_binding(&target->notify_binding, &style->notify_binding);
 		target->spec.notify_binding = true;
+	}
+
+	if (style->spec.timeout_binding) {
+		copy_binding(&target->timeout_binding, &style->timeout_binding);
+		target->spec.timeout_binding = true;
 	}
 
 	return true;
@@ -678,6 +684,9 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		} else if (strcmp(name, "on-notify") == 0) {
 			copy_binding(&style->notify_binding, &binding);
 			style->spec.notify_binding = true;
+		} else if (strcmp(name, "on-timeout") == 0) {
+			copy_binding(&style->timeout_binding, &binding);
+			style->spec.timeout_binding = true;
 		} else {
 			return false;
 		}

--- a/config.c
+++ b/config.c
@@ -150,6 +150,7 @@ void finish_style(struct mako_style *style) {
 	finish_binding(&style->touch_binding);
 	finish_binding(&style->notify_binding);
 	finish_binding(&style->timeout_binding);
+	finish_binding(&style->dismiss_binding);
 	free(style->icon_path);
 	free(style->font);
 	free(style->format);
@@ -394,6 +395,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 	if (style->spec.timeout_binding) {
 		copy_binding(&target->timeout_binding, &style->timeout_binding);
 		target->spec.timeout_binding = true;
+	}
+
+	if (style->spec.dismiss_binding) {
+		copy_binding(&target->dismiss_binding, &style->dismiss_binding);
+		target->spec.dismiss_binding = true;
 	}
 
 	return true;
@@ -687,6 +693,9 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		} else if (strcmp(name, "on-timeout") == 0) {
 			copy_binding(&style->timeout_binding, &binding);
 			style->spec.timeout_binding = true;
+		} else if (strcmp(name, "on-dismiss") == 0) {
+			copy_binding(&style->dismiss_binding, &binding);
+			style->spec.dismiss_binding = true;
 		} else {
 			return false;
 		}

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -440,7 +440,8 @@ static int handle_close_notification(sd_bus_message *msg, void *data,
 	struct mako_state *state = data;
 
 	uint32_t id;
-	int ret = sd_bus_message_read(msg, "u", &id);
+	bool add_to_history = true;
+	int ret = sd_bus_message_read(msg, "ub", &id, &add_to_history);
 	if (ret < 0) {
 		return ret;
 	}
@@ -449,7 +450,7 @@ static int handle_close_notification(sd_bus_message *msg, void *data,
 	struct mako_notification *notif = get_notification(state, id);
 	if (notif) {
 		struct mako_surface *surface = notif->surface;
-		close_notification(notif, MAKO_NOTIFICATION_CLOSE_REQUEST, true);
+		close_notification(notif, MAKO_NOTIFICATION_CLOSE_REQUEST, add_to_history);
 		set_dirty(surface);
 	}
 

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -491,6 +491,7 @@ void notify_notification_closed(struct mako_notification *notif,
 
 	sd_bus_emit_signal(state->bus, service_path, service_interface,
 		"NotificationClosed", "uu", notif->id, reason);
+	notification_execute_binding(notif, &notif->style.dismiss_binding, NULL);
 }
 
 void notify_action_invoked(struct mako_action *action,

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -452,6 +452,7 @@ static int handle_close_notification(sd_bus_message *msg, void *data,
 	if (notif) {
 		struct mako_surface *surface = notif->surface;
 		close_notification(notif, MAKO_NOTIFICATION_CLOSE_REQUEST, add_to_history);
+		notification_execute_binding(notif, &notif->style.dismiss_binding, NULL);
 		set_dirty(surface);
 	}
 

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -88,6 +88,7 @@ static void handle_notification_timer(void *data) {
 	notif->timer = NULL;
 
 	close_notification(notif, MAKO_NOTIFICATION_CLOSE_EXPIRED, true);
+	notification_execute_binding(notif, &notif->style.timeout_binding, NULL);
 	set_dirty(surface);
 }
 

--- a/include/config.h
+++ b/include/config.h
@@ -49,7 +49,7 @@ struct mako_style_spec {
 	struct {
 		bool left, right, middle;
 	} button_bindings;
-	bool touch_binding, notify_binding, timeout_binding;
+	bool touch_binding, notify_binding, timeout_binding, dismiss_binding;
 };
 
 
@@ -98,7 +98,7 @@ struct mako_style {
 	struct {
 		struct mako_binding left, right, middle;
 	} button_bindings;
-	struct mako_binding touch_binding, notify_binding, timeout_binding;
+	struct mako_binding touch_binding, notify_binding, timeout_binding, dismiss_binding;
 };
 
 struct mako_config {

--- a/include/config.h
+++ b/include/config.h
@@ -49,7 +49,7 @@ struct mako_style_spec {
 	struct {
 		bool left, right, middle;
 	} button_bindings;
-	bool touch_binding, notify_binding;
+	bool touch_binding, notify_binding, timeout_binding;
 };
 
 
@@ -98,7 +98,7 @@ struct mako_style {
 	struct {
 		struct mako_binding left, right, middle;
 	} button_bindings;
-	struct mako_binding touch_binding, notify_binding;
+	struct mako_binding touch_binding, notify_binding, timeout_binding;
 };
 
 struct mako_config {

--- a/include/notification.h
+++ b/include/notification.h
@@ -88,9 +88,11 @@ void close_notification(struct mako_notification *notif,
 	enum mako_notification_close_reason reason,
 	bool add_to_history);
 void close_group_notifications(struct mako_notification *notif,
-	enum mako_notification_close_reason reason);
+	enum mako_notification_close_reason reason,
+	bool add_to_history);
 void close_all_notifications(struct mako_state *state,
-	enum mako_notification_close_reason reason);
+	enum mako_notification_close_reason reason,
+	bool add_to_history);
 char *format_hidden_text(char variable, bool *markup, void *data);
 char *format_notif_text(char variable, bool *markup, void *data);
 size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data);

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -60,6 +60,11 @@ Supported options:
 
 	Default: none
 
+*on-timeout*=_action_
+	Performs the action when the notification times out.
+
+	Default: none
+
 Supported actions:
 
 *none*

--- a/mako.5.scd
+++ b/mako.5.scd
@@ -65,6 +65,11 @@ Supported options:
 
 	Default: none
 
+*on-dismiss*=_action_
+	Performs the action when the notification is dismissed.
+
+	Default: none
+
 Supported actions:
 
 *none*

--- a/makoctl
+++ b/makoctl
@@ -8,8 +8,8 @@ usage() {
 	echo "                                 given id, or the last notification"
 	echo "                                 if none is given"
 	echo "          [-a|--all]             Dismiss all notifications"
-	echo "          [-g|--group]           Dismiss all the notifications"
-	echo "                                 in the last notification's group"
+	echo "          [-g|--group]           Dismiss all the notifications in the"
+	echo "                                 last or given notification's group"
 	echo "  restore                        Restore the most recently expired"
 	echo "                                 notification from the history buffer"
 	echo "  invoke [-n id] [action]        Invoke an action on the notification"
@@ -85,8 +85,10 @@ case "$1" in
 
 	if [ $all -eq 1 ]; then
 		call DismissAllNotifications
+	elif [ $group -eq 1 ]; then
+		call DismissGroupNotifications "u" "$id"
 	else
-		call DismissNotification "ub" "$id" "$group"
+		call DismissNotification "u" "$id"
 	fi
 	;;
 "invoke")

--- a/makoctl
+++ b/makoctl
@@ -9,6 +9,7 @@ usage() {
 	echo "                                 if none is given"
 	echo "          [-a|--all]             Dismiss all notifications"
 	echo "          [-g|--group]           Dismiss all the notifications in the"
+	echo "          [--no-history]         Dismiss without adding the history"
 	echo "                                 last or given notification's group"
 	echo "  restore                        Restore the most recently expired"
 	echo "                                 notification from the history buffer"
@@ -58,6 +59,7 @@ case "$1" in
 "dismiss")
 	all=0
 	group=0
+	add_to_history=1
 	id=0
 	while [ $# -gt 1 ]; do
 		case "$2" in
@@ -66,6 +68,9 @@ case "$1" in
 			;;
 		"-g"|"--group")
 			group=1
+			;;
+		"--no-history")
+			add_to_history=0
 			;;
 		"-n")
 			if [ $# -lt 3 ]; then
@@ -84,11 +89,11 @@ case "$1" in
 	done
 
 	if [ $all -eq 1 ]; then
-		call DismissAllNotifications
+		call DismissAllNotifications "b" "$add_to_history"
 	elif [ $group -eq 1 ]; then
-		call DismissGroupNotifications "u" "$id"
+		call DismissGroupNotifications "ub" "$id" "$add_to_history"
 	else
-		call DismissNotification "u" "$id"
+		call DismissNotification "ub" "$id" "$add_to_history"
 	fi
 	;;
 "invoke")

--- a/notification.c
+++ b/notification.c
@@ -168,12 +168,13 @@ struct mako_notification *get_tagged_notification(struct mako_state *state,
 }
 
 void close_group_notifications(struct mako_notification *top_notif,
-	       enum mako_notification_close_reason reason) {
+		enum mako_notification_close_reason reason,
+		bool add_to_history) {
 	struct mako_state *state = top_notif->state;
 
 	if (top_notif->style.group_criteria_spec.none) {
 		// No grouping, just close the notification
-		close_notification(top_notif, reason, true);
+		close_notification(top_notif, reason, add_to_history);
 		return;
 	}
 
@@ -183,7 +184,7 @@ void close_group_notifications(struct mako_notification *top_notif,
 	struct mako_notification *notif, *tmp;
 	wl_list_for_each_safe(notif, tmp, &state->notifications, link) {
 		if (match_criteria(notif_criteria, notif)) {
-			close_notification(notif, reason, true);
+			close_notification(notif, reason, add_to_history);
 		}
 	}
 
@@ -191,10 +192,11 @@ void close_group_notifications(struct mako_notification *top_notif,
 }
 
 void close_all_notifications(struct mako_state *state,
-		enum mako_notification_close_reason reason) {
+		enum mako_notification_close_reason reason,
+		bool add_to_history) {
 	struct mako_notification *notif, *tmp;
 	wl_list_for_each_safe(notif, tmp, &state->notifications, link) {
-		close_notification(notif, reason, true);
+		close_notification(notif, reason, add_to_history);
 	}
 }
 
@@ -386,10 +388,10 @@ void notification_execute_binding(struct mako_notification *notif,
 		close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, false);
 		break;
 	case MAKO_BINDING_DISMISS_GROUP:
-		close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+		close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, true);
 		break;
 	case MAKO_BINDING_DISMISS_ALL:
-		close_all_notifications(notif->state, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+		close_all_notifications(notif->state, MAKO_NOTIFICATION_CLOSE_DISMISSED, true);
 		break;
 	case MAKO_BINDING_INVOKE_ACTION:
 		assert(binding->action_name != NULL);


### PR DESCRIPTION
Hi,
the recently introduced `dismiss --no-history` feature is very helpful to me.
However, afaics, it's only usable when clicking the notification itself, not through the dbus API (or I'm blind) - and therefore neither with `makoctl`.

I tried to get familiar with the codebase to add a parameter for dbus calls and it seems a bit weird to me.
For my elaboration, I'd like to exclude `DismissAllNotifications()`, as this one is self-explanatory.
For the rest, there are currently 3 function signatures for 4 situations.
If there's an ID given, `DismissNotification()` is used to dismiss whole groups as well, not `DismissGroupNotifications()`.
I drafted a proposal of what would be easier to understand IMHO[^1]:

ID given? | Whole group? | Current                        | Proposal
---       | ---          | ---                            | ---
0         | 0            | DismissLastNotification()      | DismissLastNotification(false)
0         | 1            | DismissGroupNotifications()    | DismissLastNotification(true)
1         | 0            | DismissNotification(id, false) | DismissNotification(id, false)
1         | 1            | DismissNotification(id, true)  | DismissNotification(id, true)

[^1]: of course, with 2 params it would also be possible to handle all those cases in one function (e.g. id=0 for last), but I'm not sure if this would go too far.

I've implemented this draft in the given PR.

Features/use cases:
- choose whether _group_ and _all_ notifications should appear in history (not only single ones)
- choose whether notifications should appear in history via dbus
- activate actions not only when receiving them but also on timeout and/or dismissal
- possibility to keep an indicator showing the current num of (missed) notifications without periodically polling mako

I'm aware of the implications an API change could entail and I haven't been involved in this project. I don't claim to say that change would make sense here, I'd just like to ask

- is extending the --no-history functionality even interesting?
- is an API change even open to discussion?
- general comments?
