### PR TITLE
Readme: Improved support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,20 @@ Feel free to join the IRC channel: #emersion on irc.libera.chat.
 
 ## Running
 
+`mako` requires an active session bus to function properly. 
 
-`mako` will run automatically when a notification is emitted. This happens via
-D-Bus activation, so you don't really need to explicitly start it up (this also
-allows delaying its startup time and speed up system startup).
+If you are using SystemD `mako` will run automatically when a notification is emitted.
+This happens via D-Bus activation, so you don't really need to explicitly 
+start it up (this also allows delaying its startup time and speed up system startup).
 
+If you are not using systemd, you might need to manually start a dbus user session
+with the compositor of your choice from the display manager. The command run should
+look something like this: `dbus-launch --exit-with-session COMPOSITOR`.
+
+### Multiple notification daemons
 If you have several notification daemons installed though, you might want to
-explicitly start this one. Some ways of achieving this is:
-
-- If you're using Sway you can start mako on launch by putting `exec mako` in
-  your configuration file.
-
-- If you are not using systemd, you might need to manually start a dbus user
-  session: `dbus-daemon --session --address=unix:path=$XDG_RUNTIME_DIR/bus`
+explicitly start this one.
+This is usually done by putting `exec mako` in your compositor's configuration file.
 
 ## Configuration
 


### PR DESCRIPTION
I have extracted "Multiple notification daemons" to another section.

Also I have added a line explaining that mako needs a session bus.

Later I have split systemd and non-systemd systems into two paragraphs

Related to #507

PS. Sorry for the fuss, I don't really have experience with stuff like that