### PR TITLE
Implement `makoctl count` script command with variants

### DIFF
--- a/makoctl
+++ b/makoctl
@@ -4,6 +4,7 @@ usage() {
 	echo "Usage: makoctl <command> [options...]"
 	echo ""
 	echo "Commands:"
+	echo "  count [waiting|history]        Show the number of notifications"
 	echo "  dismiss [-n id]                Dismiss the notification with the"
 	echo "                                 given id, or the last notification"
 	echo "                                 if none is given"
@@ -56,6 +57,24 @@ if [ $# -eq 0 ]; then
 fi
 
 case "$1" in
+"count")
+	require_jq
+  if [ $# -gt 1 ]; then
+  	case "$2" in
+  		waiting)
+        call ListNotifications | jq -re '.data[0] | length'
+        ;;
+      history)
+        call ListHistory | jq -re '.data[0] | length'
+        ;;
+      *)
+      	echo >&2 "$0: Expected 'waiting' or 'history' after 'count', got '$2'"
+      	;;
+    esac
+	else
+  	echo >&2 "$0: Expected 'waiting' or 'history' after 'count', got nothing"
+  fi
+	;;
 "dismiss")
 	all=0
 	group=0


### PR DESCRIPTION
This PR adds new command to `makoctl` as `makoctl count`. It allows a user to get number of notifications that are currently in history or in a waiting state. It may be useful for software producing a lot of notifications (e.g. single-point DBs) or any other use case where notifications are used as counter for something. The result looks like this:
```
{
        "type" : "u",
        "data" : [
             5
        ]
}
```
...where `5` is the number of notifications in the history or on the screen (_waiting_) at the moment.

See also original idea from 2017 in [dunst](https://github.com/dunst-project/dunst). It is the same sub-command that was [initially named `status`, and now named `count`](https://github.com/dunst-project/dunst/commit/4d74c7b46e7a1e9660f5f116947bdbd09ce8ead8): [issue](https://github.com/dunst-project/dunst/issues/445), [commit](https://github.com/dunst-project/dunst/commit/137361a95dbf4064668f32d4872fa3093e2c1db3).