### PR TITLE
Feature: icon-border-radius

### DIFF
--- a/config.c
+++ b/config.c
@@ -100,6 +100,7 @@ void init_default_style(struct mako_style *style) {
 #endif
 	style->max_icon_size = 64;
 	style->icon_path = strdup("");  // hicolor and pixmaps are implicit.
+	style->icon_border_radius = 0;
 
 	style->font = strdup("monospace 10");
 	style->markup = true;
@@ -266,6 +267,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 		free(target->icon_path);
 		target->icon_path = new_icon_path;
 		target->spec.icon_path = true;
+	}
+
+	if (style->spec.icon_border_radius) {
+		target->icon_border_radius = style->icon_border_radius;
+		target->spec.icon_border_radius = true;
 	}
 
 	if (style->spec.font) {
@@ -608,6 +614,9 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	} else if (strcmp(name, "icon-path") == 0) {
 		free(style->icon_path);
 		return spec->icon_path = !!(style->icon_path = strdup(value));
+	} else if (strcmp(name, "icon-border-radius") == 0) {
+		spec->icon_border_radius = parse_int_ge(value, &style->icon_border_radius, 0);
+		return spec->icon_border_radius;
 	} else if (strcmp(name, "markup") == 0) {
 		return spec->markup = parse_boolean(value, &style->markup);
 	} else if (strcmp(name, "actions") == 0) {
@@ -903,6 +912,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"icon-location", required_argument, 0, 0},
 		{"icon-path", required_argument, 0, 0},
 		{"max-icon-size", required_argument, 0, 0},
+		{"icon-border-radius", required_argument, 0, 0},
 		{"markup", required_argument, 0, 0},
 		{"actions", required_argument, 0, 0},
 		{"format", required_argument, 0, 0},

--- a/contrib/completions/bash/mako
+++ b/contrib/completions/bash/mako
@@ -23,6 +23,7 @@ _mako()
     '--icons'
     '--icon-path'
     '--max-icon-size'
+    '--icon-border-radius'
     '--markup'
     '--actions'
     '--format'

--- a/contrib/completions/fish/mako.fish
+++ b/contrib/completions/fish/mako.fish
@@ -22,6 +22,7 @@ complete -c mako -l progress-color -d 'Progress color indicator' -x
 complete -c mako -l icons -d 'Show icons or not' -xa "1 0"
 complete -c mako -l icon-path -d 'Icon search path, colon delimited' -r
 complete -c mako -l max-icon-size -d 'Max icon size in px' -x
+complete -c mako -l icon-border-radius -d 'Icon border radius value in px' -x
 complete -c mako -l markup -d 'Enable markup or not' -xa "1 0"
 complete -c mako -l actions -d 'Enable actions or not' -xa "1 0"
 complete -c mako -l format -d 'Format string' -x

--- a/contrib/completions/zsh/_mako
+++ b/contrib/completions/zsh/_mako
@@ -17,6 +17,7 @@ _arguments \
     '--border-size[Border size.]:size:' \
     '--border-color[Border color.]:color:' \
     '--border-radius[Corner radius values, comma separated. Up to four values, with the same meaning as in CSS.]:radius:' \
+    '--icon-border-radius[Icon corner radius value.]:radius:' \
     '--markup[Enable/disable markup.]:markup enabled:(0 1)' \
     '--actions[Applications may request an action to be associated with activating a notification. Disabling this will cause mako to ignore these requests.]:action enabled:(0 1)' \
     '--format[Format string.]:format:' \

--- a/doc/mako.5.scd
+++ b/doc/mako.5.scd
@@ -224,6 +224,11 @@ Supported actions:
 
 	Default: left
 
+*icon-border-radius*=_px_
+	Sets icon corner radius to _px_ pixels.
+
+	Default: 0
+
 *markup*=0|1
 	If 1, enable Pango markup. If 0, disable Pango markup. If enabled, Pango
 	markup will be interpreted in your format specifier and in the body of

--- a/include/config.h
+++ b/include/config.h
@@ -41,7 +41,7 @@ enum mako_icon_location {
 struct mako_style_spec {
 	bool width, height, outer_margin, margin, padding, border_size, border_radius, font,
 		markup, format, text_alignment, actions, default_timeout, ignore_timeout,
-		icons, max_icon_size, icon_path, group_criteria_spec, invisible, history,
+		icons, max_icon_size, icon_path, icon_border_radius, group_criteria_spec, invisible, history,
 		icon_location, max_visible, layer, output, anchor;
 	struct {
 		bool background, text, border, progress;
@@ -67,6 +67,7 @@ struct mako_style {
 	bool icons;
 	int32_t max_icon_size;
 	char *icon_path;
+	int32_t icon_border_radius;
 
 	char *font;
 	bool markup;

--- a/include/icon.h
+++ b/include/icon.h
@@ -8,6 +8,7 @@ struct mako_icon {
 	double width;
 	double height;
 	double scale;
+	int32_t border_radius;
 	cairo_surface_t *image;
 };
 

--- a/main.c
+++ b/main.c
@@ -39,6 +39,7 @@ static const char usage[] =
 	"      --icons <0|1>                   Show icons in notifications.\n"
 	"      --icon-path <path>[:<path>...]  Icon search path, colon delimited.\n"
 	"      --max-icon-size <px>            Set max size of icons.\n"
+	"      --icon-border-radius <px>       Icon's corner radius.\n"
 	"      --markup <0|1>                  Enable/disable markup.\n"
 	"      --actions <0|1>                 Enable/disable application action\n"
 	"                                      execution.\n"

--- a/render.c
+++ b/render.c
@@ -105,6 +105,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 	int radius_right = style->border_radius.right;
 	int radius_bottom = style->border_radius.bottom;
 	int radius_left = style->border_radius.left;
+	int icon_radius = style->icon_border_radius;
 	bool icon_vertical = style->icon_location == MAKO_ICON_LOCATION_TOP ||
 		style->icon_location == MAKO_ICON_LOCATION_BOTTOM;
 
@@ -300,7 +301,11 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 				style->padding.bottom - icon->height;
 			break;
 		}
+		cairo_save(cairo);
+		set_rounded_rectangle(cairo, xpos, ypos, icon->width, icon->height, scale, icon_radius, icon_radius, icon_radius, icon_radius);
+		cairo_clip(cairo);
 		draw_icon(cairo, icon, xpos, ypos, scale);
+		cairo_restore(cairo);
 	}
 
 	if (icon_vertical) {


### PR DESCRIPTION
Solves #454 ~~though I'm concerned about the fact that I have duplicated code with the `rounded_square` function in `icon.c` where it basically achieves the same purpose as the `set_rounded_rectangle` in `render.c`.~~