### PR TITLE
fix(makoct): Ensure same notif id is used across external call in `makoctl menu`

### DIFF
--- a/makoctl
+++ b/makoctl
@@ -112,11 +112,17 @@ case "$1" in
 	require_jq
 	if [ $# -gt 1 ] && [ "$1" = "-n" ]; then
 		id="$2"
-		actions="$(call ListNotifications | jq --arg id "$id" -re '.data[0][] | select(.id.data==($id | tonumber)) | .actions.data')"
+		if [ $id -eq 0 ]; then
+			actions="$(call ListNotifications | jq -re '.data[0][0].actions.data')"
+		else
+			actions="$(call ListNotifications | jq --arg id "$id" -re '.data[0][] | select(.id.data==($id | tonumber)) | .actions.data')"
+		fi
 		shift 2
 	else
-		actions="$(call ListNotifications | jq -re '.data[0][0].actions.data')"
-		id="0"
+		notification_list="$(call ListNotifications)"
+		actions="$(echo "$notification_list" | jq -re '.data[0][0].actions.data')"
+		id="$(echo "$notification_list" | jq -re '.data[0][0].id.data')"
+		unset notification_list
 	fi
 	if [ "$(jq -rn "$actions | length")" -eq "0" ]; then
 		echo >&2 "$0: No actions found"


### PR DESCRIPTION
Consider the following:
The first notification has action `act1`. The user starts `makoctl menu` with no id specified to get actions from this notifications. While dmenu is open, a new notification appears. When the user confirms `act1` in dmenu, this action previously got applied to this new notification, which potentially has completely different actions/semantics.

Now the behaviour is that the action gets sent to the notification from which it was obtained (this is consistent with behaviour when `-n` is passed)

### Notes
The new behaviour could already be replicated on the user's side, but there doesn't seem to be a point in keeping the previous behaviour. The previous behaviour can be achieved by passing `-n 0`