### PR TITLE
README: Fixed broken freedesktop link. Linted with markdownlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,5 @@ See the [faq section in the wiki](https://github.com/emersion/mako/wiki/Frequent
 
 MIT
 
-[spec]: https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
+[spec]: https://specifications.freedesktop.org/notification-spec/latest/
 [basu]: https://github.com/emersion/basu

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Feel free to join the IRC channel: #emersion on irc.libera.chat.
 
 ## Running
 
-
 `mako` will run automatically when a notification is emitted. This happens via
 D-Bus activation, so you don't really need to explicitly start it up (this also
 allows delaying its startup time and speed up system startup).
@@ -37,15 +36,15 @@ For control of mako during runtime, `makoctl` can be used; see `man makoctl`
 
 Install dependencies:
 
-* meson (build-time dependency)
-* wayland
-* pango
-* cairo
-* systemd, elogind or [basu] (for the sd-bus library)
-* gdk-pixbuf (optional, for icons support)
-* dbus (runtime dependency, user-session support is required)
-* scdoc (optional, for man pages)
-* jq (optional, runtime dependency)
+- meson (build-time dependency)
+- wayland
+- pango
+- cairo
+- systemd, elogind or [basu] (for the sd-bus library)
+- gdk-pixbuf (optional, for icons support)
+- dbus (runtime dependency, user-session support is required)
+- scdoc (optional, for man pages)
+- jq (optional, runtime dependency)
 
 Then run:
 
@@ -59,7 +58,7 @@ build/mako
   <img src="https://sr.ht/frOL.jpg" alt="mako">
 </p>
 
-## I have a question!
+## I have a question
 
 See the [faq section in the wiki](https://github.com/emersion/mako/wiki/Frequently-asked-questions).
 
@@ -67,5 +66,5 @@ See the [faq section in the wiki](https://github.com/emersion/mako/wiki/Frequent
 
 MIT
 
-[spec]: https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
+[spec]: https://specifications.freedesktop.org/notification-spec/latest/
 [basu]: https://github.com/emersion/basu

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Feel free to join the IRC channel: #emersion on irc.libera.chat.
 
 ## Running
 
+
 `mako` will run automatically when a notification is emitted. This happens via
 D-Bus activation, so you don't really need to explicitly start it up (this also
 allows delaying its startup time and speed up system startup).
@@ -36,15 +37,15 @@ For control of mako during runtime, `makoctl` can be used; see `man makoctl`
 
 Install dependencies:
 
-- meson (build-time dependency)
-- wayland
-- pango
-- cairo
-- systemd, elogind or [basu] (for the sd-bus library)
-- gdk-pixbuf (optional, for icons support)
-- dbus (runtime dependency, user-session support is required)
-- scdoc (optional, for man pages)
-- jq (optional, runtime dependency)
+* meson (build-time dependency)
+* wayland
+* pango
+* cairo
+* systemd, elogind or [basu] (for the sd-bus library)
+* gdk-pixbuf (optional, for icons support)
+* dbus (runtime dependency, user-session support is required)
+* scdoc (optional, for man pages)
+* jq (optional, runtime dependency)
 
 Then run:
 
@@ -58,7 +59,7 @@ build/mako
   <img src="https://sr.ht/frOL.jpg" alt="mako">
 </p>
 
-## I have a question
+## I have a question!
 
 See the [faq section in the wiki](https://github.com/emersion/mako/wiki/Frequently-asked-questions).
 
@@ -66,5 +67,5 @@ See the [faq section in the wiki](https://github.com/emersion/mako/wiki/Frequent
 
 MIT
 
-[spec]: https://specifications.freedesktop.org/notification-spec/latest/
+[spec]: https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
 [basu]: https://github.com/emersion/basu


### PR DESCRIPTION
This pull request is mostly to fix the broken link to the Freedesktop specification, since the original link appears to be gone/broken. (Line 69/70)

I use [markdownlint](https://github.com/DavidAnson/markdownlint) and it happened to catch/fix more than I intended... (Lint on save got me...)

However, the other changes it made does push the README.md closer to the [CommonMark](https://spec.commonmark.org/current/) specification if you are OK with leaving them in.

From what I can see visually in the GitHub previewer, nothing changed visually from the current version. But, I understand if you don't wish to change the other formatting.

Thank you.