### PR TITLE
dbus: add Modes property

### DIFF
--- a/include/dbus.h
+++ b/include/dbus.h
@@ -25,6 +25,8 @@ void notify_action_invoked(struct mako_action *action,
 
 int init_dbus_xdg(struct mako_state *state);
 
+void emit_modes_changed(struct mako_state *state);
+
 int init_dbus_mako(struct mako_state *state);
 
 #endif

--- a/mode.c
+++ b/mode.c
@@ -4,6 +4,7 @@
 
 #include "mako.h"
 #include "mode.h"
+#include "dbus.h"
 
 bool has_mode(struct mako_state *state, const char *mode) {
 	const char **mode_ptr;
@@ -38,4 +39,6 @@ void set_modes(struct mako_state *state, const char **modes, size_t modes_len) {
 		char **dst = wl_array_add(&state->current_modes, sizeof(char *));
 		*dst = strdup(modes[i]);
 	}
+
+	emit_modes_changed(state);
 }


### PR DESCRIPTION
This adds a dbus property `Modes` and invalidates it on changes.
Dbus clients can subscribe to these invalidations to react in real time.