### PR TITLE
Fix use after free when closing notifications

### DIFF
--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -57,8 +57,9 @@ static int handle_dismiss_last_notification(sd_bus_message *msg, void *data,
 
 	struct mako_notification *notif =
 		wl_container_of(state->notifications.next, notif, link);
+	struct mako_surface *surface = notif->surface;
 	close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, true);
-	set_dirty(notif->surface);
+	set_dirty(surface);
 
 done:
 	return sd_bus_reply_method_return(msg, "");
@@ -78,12 +79,13 @@ static int handle_dismiss_notification(sd_bus_message *msg, void *data,
 	struct mako_notification *notif;
 	wl_list_for_each(notif, &state->notifications, link) {
 		if (notif->id == id || id == 0) {
+			struct mako_surface *surface = notif->surface;
 			if (dismiss_group) {
 				close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
 			} else {
 				close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, true);
 			}
-			set_dirty(notif->surface);
+			set_dirty(surface);
 			break;
 		}
 	}


### PR DESCRIPTION
This might be related to https://github.com/emersion/mako/issues/512, as the problem I saw had similar symptoms. But at some point, I started to see segfaults each time I closed a notification, regardless of whether I (un)plugged monitors.

The crux of the issue is that closing a notification frees it, and in some cases the notification was being used after being closed.