### PR TITLE
Unify Dismiss* methods and add --no-history to `makoctl`

### DIFF
--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -14,76 +14,72 @@
 static const char *service_path = "/fr/emersion/Mako";
 static const char *service_interface = "fr.emersion.Mako";
 
-static int handle_dismiss_all_notifications(sd_bus_message *msg, void *data,
-		sd_bus_error *ret_error) {
-	struct mako_state *state = data;
-
-	close_all_notifications(state, MAKO_NOTIFICATION_CLOSE_DISMISSED);
-	struct mako_surface *surface;
-
-	wl_list_for_each(surface, &state->surfaces, link) {
-		set_dirty(surface);
-	}
-
-	return sd_bus_reply_method_return(msg, "");
-}
-
-static int handle_dismiss_group_notifications(sd_bus_message *msg, void *data,
-		sd_bus_error *ret_error) {
-	struct mako_state *state = data;
-
-	if (wl_list_empty(&state->notifications)) {
-		goto done;
-	}
-
-	struct mako_notification *notif =
-		wl_container_of(state->notifications.next, notif, link);
-
-	struct mako_surface *surface = notif->surface;
-	close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
-	set_dirty(surface);
-
-done:
-	return sd_bus_reply_method_return(msg, "");
-}
-
-static int handle_dismiss_last_notification(sd_bus_message *msg, void *data,
-		sd_bus_error *ret_error) {
-	struct mako_state *state = data;
-
-	if (wl_list_empty(&state->notifications)) {
-		goto done;
-	}
-
-	struct mako_notification *notif =
-		wl_container_of(state->notifications.next, notif, link);
-	struct mako_surface *surface = notif->surface;
-	close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, true);
-	set_dirty(surface);
-
-done:
-	return sd_bus_reply_method_return(msg, "");
-}
-
-static int handle_dismiss_notification(sd_bus_message *msg, void *data,
+static int handle_dismiss(sd_bus_message *msg, void *data,
 		sd_bus_error *ret_error) {
 	struct mako_state *state = data;
 
 	uint32_t id = 0;
-	int dismiss_group = 0;
-	int ret = sd_bus_message_read(msg, "ub", &id, &dismiss_group);
+	int group = 0;
+	int all = 0;
+	int history = 1; // Keep history be default
+
+	int ret = sd_bus_message_enter_container(msg, 'a', "{sv}");
 	if (ret < 0) {
 		return ret;
+	}
+
+	while (true) {
+		ret = sd_bus_message_enter_container(msg, 'e', "sv");
+		if (ret < 0) {
+			return ret;
+		} else if (ret == 0) {
+			break;
+		}
+
+		const char *key = NULL;
+		ret = sd_bus_message_read(msg, "s", &key);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (strcmp(key, "id") == 0) {
+			ret = sd_bus_message_read(msg, "v", "u", &id);
+		} else if (strcmp(key, "group") == 0) {
+			ret = sd_bus_message_read(msg, "v", "b", &group);
+		} else if (strcmp(key, "history") == 0) {
+			ret = sd_bus_message_read(msg, "v", "b", &history);
+		} else if (strcmp(key, "all") == 0) {
+			ret = sd_bus_message_read(msg, "v", "b", &all);
+		} else {
+			ret = sd_bus_message_skip(msg, "v");
+		}
+		if (ret < 0) {
+			return ret;
+		}
+
+		ret = sd_bus_message_exit_container(msg);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	// These don't make sense together
+	if (all && group) {
+		return -EINVAL;
+	} else if ((all || group) && id != 0) {
+		return -EINVAL;
 	}
 
 	struct mako_notification *notif;
 	wl_list_for_each(notif, &state->notifications, link) {
 		if (notif->id == id || id == 0) {
 			struct mako_surface *surface = notif->surface;
-			if (dismiss_group) {
-				close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+			if (group) {
+				close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, history);
+			} else if (all) {
+				close_all_notifications(state, MAKO_NOTIFICATION_CLOSE_DISMISSED, history);
 			} else {
-				close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, true);
+				close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, history);
 			}
 			set_dirty(surface);
 			break;
@@ -468,10 +464,7 @@ void emit_modes_changed(struct mako_state *state) {
 
 static const sd_bus_vtable service_vtable[] = {
 	SD_BUS_VTABLE_START(0),
-	SD_BUS_METHOD("DismissAllNotifications", "", "", handle_dismiss_all_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("DismissGroupNotifications", "", "", handle_dismiss_group_notifications, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("DismissLastNotification", "", "", handle_dismiss_last_notification, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("DismissNotification", "ub", "", handle_dismiss_notification, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("DismissNotifications", "a{sv}", "", handle_dismiss, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("InvokeAction", "us", "", handle_invoke_action, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("RestoreNotification", "", "", handle_restore_action, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("ListNotifications", "", "aa{sv}", handle_list_notifications, SD_BUS_VTABLE_UNPRIVILEGED),

--- a/doc/makoctl.1.scd
+++ b/doc/makoctl.1.scd
@@ -25,6 +25,9 @@ Sends IPC commands to the running mako daemon via dbus.
 	*-g, --group*
 		Dismiss the first notification group.
 
+	*-h, --no-history*
+		Dismiss the current notification without adding it to history.
+
 	*-n* <id>
 		Dismiss the notification with the given id. Defaults to the first
 		notification.

--- a/include/notification.h
+++ b/include/notification.h
@@ -88,9 +88,9 @@ void close_notification(struct mako_notification *notif,
 	enum mako_notification_close_reason reason,
 	bool add_to_history);
 void close_group_notifications(struct mako_notification *notif,
-	enum mako_notification_close_reason reason);
+	enum mako_notification_close_reason reason, bool add_to_history);
 void close_all_notifications(struct mako_state *state,
-	enum mako_notification_close_reason reason);
+	enum mako_notification_close_reason reason, bool add_to_history);
 char *format_hidden_text(char variable, bool *markup, void *data);
 char *format_notif_text(char variable, bool *markup, void *data);
 size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data);

--- a/notification.c
+++ b/notification.c
@@ -167,12 +167,13 @@ struct mako_notification *get_tagged_notification(struct mako_state *state,
 }
 
 void close_group_notifications(struct mako_notification *top_notif,
-	       enum mako_notification_close_reason reason) {
+		enum mako_notification_close_reason reason,
+		bool add_to_history) {
 	struct mako_state *state = top_notif->state;
 
 	if (top_notif->style.group_criteria_spec.none) {
 		// No grouping, just close the notification
-		close_notification(top_notif, reason, true);
+		close_notification(top_notif, reason, add_to_history);
 		return;
 	}
 
@@ -182,7 +183,7 @@ void close_group_notifications(struct mako_notification *top_notif,
 	struct mako_notification *notif, *tmp;
 	wl_list_for_each_safe(notif, tmp, &state->notifications, link) {
 		if (match_criteria(notif_criteria, notif)) {
-			close_notification(notif, reason, true);
+			close_notification(notif, reason, add_to_history);
 		}
 	}
 
@@ -190,10 +191,11 @@ void close_group_notifications(struct mako_notification *top_notif,
 }
 
 void close_all_notifications(struct mako_state *state,
-		enum mako_notification_close_reason reason) {
+		enum mako_notification_close_reason reason,
+		bool add_to_history) {
 	struct mako_notification *notif, *tmp;
 	wl_list_for_each_safe(notif, tmp, &state->notifications, link) {
-		close_notification(notif, reason, true);
+		close_notification(notif, reason, add_to_history);
 	}
 }
 
@@ -385,10 +387,10 @@ void notification_execute_binding(struct mako_notification *notif,
 		close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, false);
 		break;
 	case MAKO_BINDING_DISMISS_GROUP:
-		close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+		close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, true);
 		break;
 	case MAKO_BINDING_DISMISS_ALL:
-		close_all_notifications(notif->state, MAKO_NOTIFICATION_CLOSE_DISMISSED);
+		close_all_notifications(notif->state, MAKO_NOTIFICATION_CLOSE_DISMISSED, true);
 		break;
 	case MAKO_BINDING_INVOKE_ACTION:
 		assert(binding->action_name != NULL);


### PR DESCRIPTION
This PR addresses the D-Bus API clean-up mentioned in https://github.com/emersion/mako/pull/495#issuecomment-2067702141 and also makes stuff more coherent. It also adds a `--no-history` flag to `makoctl dismiss` so #495 could also be closed if this gets into master.