### PR TITLE
Add an on-closed event 

### DIFF
--- a/config.c
+++ b/config.c
@@ -154,6 +154,7 @@ void finish_style(struct mako_style *style) {
 	finish_binding(&style->button_bindings.right);
 	finish_binding(&style->touch_binding);
 	finish_binding(&style->notify_binding);
+	finish_binding(&style->closed_binding);
 	free(style->icon_path);
 	free(style->font);
 	free(style->format);
@@ -398,6 +399,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 	if (style->spec.notify_binding) {
 		copy_binding(&target->notify_binding, &style->notify_binding);
 		target->spec.notify_binding = true;
+	}
+
+	if (style->spec.closed_binding) {
+		copy_binding(&target->closed_binding, &style->closed_binding);
+		target->spec.closed_binding = true;
 	}
 
 	return true;
@@ -719,6 +725,9 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 		} else if (strcmp(name, "on-notify") == 0) {
 			copy_binding(&style->notify_binding, &binding);
 			style->spec.notify_binding = true;
+		} else if (strcmp(name, "on-closed") == 0) {
+			copy_binding(&style->closed_binding, &binding);
+			style->spec.closed_binding = true;
 		} else {
 			return false;
 		}

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -487,6 +487,8 @@ void notify_notification_closed(struct mako_notification *notif,
 
 	sd_bus_emit_signal(state->bus, service_path, service_interface,
 		"NotificationClosed", "uu", notif->id, reason);
+		
+	notification_execute_binding(notif, &notif->style.closed_binding, NULL);
 }
 
 void notify_action_invoked(struct mako_action *action,

--- a/doc/mako.5.scd
+++ b/doc/mako.5.scd
@@ -66,6 +66,11 @@ Supported options:
 
 	Default: none
 
+*on-closed*=_action_
+	Performs the action when the notification is closed.
+
+	Default: none
+
 Supported actions:
 
 *none*

--- a/include/config.h
+++ b/include/config.h
@@ -49,7 +49,7 @@ struct mako_style_spec {
 	struct {
 		bool left, right, middle;
 	} button_bindings;
-	bool touch_binding, notify_binding;
+	bool touch_binding, notify_binding, closed_binding;
 };
 
 
@@ -99,7 +99,7 @@ struct mako_style {
 	struct {
 		struct mako_binding left, right, middle;
 	} button_bindings;
-	struct mako_binding touch_binding, notify_binding;
+	struct mako_binding touch_binding, notify_binding, closed_binding;
 };
 
 struct mako_config {


### PR DESCRIPTION
In some cases (for example, informing an external monitor like waybar) it can be useful to peform an action when a notification is closed/dismissed. This PR adds a `on-closed` event to allow mako users to take such an action. 

For example, to signal waybar to reload its state, the user could add:

```
on-closed=exec pkill -SIGRTMIN+5 waybar
```