### PR TITLE
Add a Notifications DBus Property

### DIFF
--- a/include/dbus.h
+++ b/include/dbus.h
@@ -27,6 +27,8 @@ int init_dbus_xdg(struct mako_state *state);
 
 void emit_modes_changed(struct mako_state *state);
 
+void emit_notifications_changed(struct mako_state *state);
+
 int init_dbus_mako(struct mako_state *state);
 
 #endif

--- a/notification.c
+++ b/notification.c
@@ -140,6 +140,8 @@ void close_notification(struct mako_notification *notif,
 	} else {
 		destroy_notification(notif);
 	}
+
+	emit_notifications_changed(notif->state);
 }
 
 struct mako_notification *get_notification(struct mako_state *state,
@@ -503,6 +505,8 @@ void insert_notification(struct mako_state *state, struct mako_notification *not
 	}
 
 	wl_list_insert(insert_node, &notif->link);
+
+	emit_notifications_changed(state);
 }
 
 // Iterate through all of the current notifications and group any that share


### PR DESCRIPTION
This PR adds a `Notifications` property to the Mako DBus object, this holds the current list of notifications in the same format as the `ListNotifications` method and publishes state changes when notifications are added or removed.

The intention is that other applications wishing to respond to Mako's state can easily do so.

This is a followup from #578 