### PR TITLE
Handle transient notifications (#541)

### DIFF
--- a/criteria.c
+++ b/criteria.c
@@ -92,6 +92,11 @@ bool match_criteria(struct mako_criteria *criteria,
 		return false;
 	}
 
+	if (spec.transient &&
+			criteria->transient != notif->transient) {
+		return false;
+	}
+
 	if (spec.urgency &&
 			criteria->urgency != notif->urgency) {
 		return false;
@@ -480,6 +485,7 @@ struct mako_criteria *create_criteria_from_notification(
 	criteria->app_icon = strdup(notif->app_icon);
 	criteria->actionable = !wl_list_empty(&notif->actions);
 	criteria->expiring = (notif->requested_timeout != 0);
+	criteria->transient = notif->transient;
 	criteria->urgency = notif->urgency;
 	criteria->category = strdup(notif->category);
 	criteria->desktop_entry = strdup(notif->desktop_entry);

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -21,7 +21,7 @@ static int handle_dismiss(sd_bus_message *msg, void *data,
 	uint32_t id = 0;
 	int group = 0;
 	int all = 0;
-	int history = 1; // Keep history be default
+	int transient = 0; // Keep history be default
 
 	int ret = sd_bus_message_enter_container(msg, 'a', "{sv}");
 	if (ret < 0) {
@@ -46,8 +46,8 @@ static int handle_dismiss(sd_bus_message *msg, void *data,
 			ret = sd_bus_message_read(msg, "v", "u", &id);
 		} else if (strcmp(key, "group") == 0) {
 			ret = sd_bus_message_read(msg, "v", "b", &group);
-		} else if (strcmp(key, "history") == 0) {
-			ret = sd_bus_message_read(msg, "v", "b", &history);
+		} else if (strcmp(key, "transient") == 0) {
+			ret = sd_bus_message_read(msg, "v", "b", &transient);
 		} else if (strcmp(key, "all") == 0) {
 			ret = sd_bus_message_read(msg, "v", "b", &all);
 		} else {
@@ -73,14 +73,14 @@ static int handle_dismiss(sd_bus_message *msg, void *data,
 	struct mako_notification *notif;
 	wl_list_for_each(notif, &state->notifications, link) {
 		if (notif->id == id || id == 0) {
-			notif->transient = !history;
+			notif->transient = transient;
 			struct mako_surface *surface = notif->surface;
 			if (group) {
-				close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, !notif->transient);
+				close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
 			} else if (all) {
-				close_all_notifications(state, MAKO_NOTIFICATION_CLOSE_DISMISSED, !notif->transient);
+				close_all_notifications(state, MAKO_NOTIFICATION_CLOSE_DISMISSED);
 			} else {
-				close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, !notif->transient);
+				close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
 			}
 			set_dirty(surface);
 			break;

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -73,13 +73,14 @@ static int handle_dismiss(sd_bus_message *msg, void *data,
 	struct mako_notification *notif;
 	wl_list_for_each(notif, &state->notifications, link) {
 		if (notif->id == id || id == 0) {
+			notif->transient = !history;
 			struct mako_surface *surface = notif->surface;
 			if (group) {
-				close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, history);
+				close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, !notif->transient);
 			} else if (all) {
-				close_all_notifications(state, MAKO_NOTIFICATION_CLOSE_DISMISSED, history);
+				close_all_notifications(state, MAKO_NOTIFICATION_CLOSE_DISMISSED, !notif->transient);
 			} else {
-				close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, history);
+				close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, !notif->transient);
 			}
 			set_dirty(surface);
 			break;

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -86,7 +86,7 @@ static void handle_notification_timer(void *data) {
 	struct mako_surface *surface = notif->surface;
 	notif->timer = NULL;
 
-	close_notification(notif, MAKO_NOTIFICATION_CLOSE_EXPIRED, !notif->transient);
+	close_notification(notif, MAKO_NOTIFICATION_CLOSE_EXPIRED);
 	set_dirty(surface);
 }
 
@@ -452,7 +452,7 @@ static int handle_close_notification(sd_bus_message *msg, void *data,
 	struct mako_notification *notif = get_notification(state, id);
 	if (notif) {
 		struct mako_surface *surface = notif->surface;
-		close_notification(notif, MAKO_NOTIFICATION_CLOSE_REQUEST, !notif->transient);
+		close_notification(notif, MAKO_NOTIFICATION_CLOSE_REQUEST);
 		set_dirty(surface);
 	}
 

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -86,7 +86,7 @@ static void handle_notification_timer(void *data) {
 	struct mako_surface *surface = notif->surface;
 	notif->timer = NULL;
 
-	close_notification(notif, MAKO_NOTIFICATION_CLOSE_EXPIRED, true);
+	close_notification(notif, MAKO_NOTIFICATION_CLOSE_EXPIRED, !notif->transient);
 	set_dirty(surface);
 }
 
@@ -334,6 +334,10 @@ static int handle_notify(sd_bus_message *msg, void *data,
 			if (ret < 0) {
 				return ret;
 			}
+		} else if (strcmp(hint, "transient") == 0) {
+			bool transient = false;
+			ret = sd_bus_message_read(msg, "v", "b", &transient);
+			notif->transient = transient;
 		} else {
 			ret = sd_bus_message_skip(msg, "v");
 			if (ret < 0) {
@@ -448,7 +452,7 @@ static int handle_close_notification(sd_bus_message *msg, void *data,
 	struct mako_notification *notif = get_notification(state, id);
 	if (notif) {
 		struct mako_surface *surface = notif->surface;
-		close_notification(notif, MAKO_NOTIFICATION_CLOSE_REQUEST, true);
+		close_notification(notif, MAKO_NOTIFICATION_CLOSE_REQUEST, !notif->transient);
 		set_dirty(surface);
 	}
 

--- a/include/criteria.h
+++ b/include/criteria.h
@@ -25,6 +25,7 @@ struct mako_criteria {
 	char *app_icon;
 	bool actionable;  // Whether mako_notification.actions is nonempty
 	bool expiring;  // Whether mako_notification.requested_timeout is non-zero
+	bool transient;
 	enum mako_notification_urgency urgency;
 	char *category;
 	char *desktop_entry;

--- a/include/notification.h
+++ b/include/notification.h
@@ -39,6 +39,7 @@ struct mako_notification {
 	int32_t requested_timeout;
 	struct wl_list actions; // mako_action::link
 
+	bool transient;
 	enum mako_notification_urgency urgency;
 	char *category;
 	char *desktop_entry;

--- a/include/notification.h
+++ b/include/notification.h
@@ -86,12 +86,11 @@ struct mako_notification *create_notification(struct mako_state *state);
 void destroy_notification(struct mako_notification *notif);
 
 void close_notification(struct mako_notification *notif,
-	enum mako_notification_close_reason reason,
-	bool add_to_history);
+	enum mako_notification_close_reason reason);
 void close_group_notifications(struct mako_notification *notif,
-	enum mako_notification_close_reason reason, bool add_to_history);
+	enum mako_notification_close_reason reason);
 void close_all_notifications(struct mako_state *state,
-	enum mako_notification_close_reason reason, bool add_to_history);
+	enum mako_notification_close_reason reason);
 char *format_hidden_text(char variable, bool *markup, void *data);
 char *format_notif_text(char variable, bool *markup, void *data);
 size_t format_text(const char *format, char *buf, mako_format_func_t func, void *data);

--- a/include/types.h
+++ b/include/types.h
@@ -47,6 +47,7 @@ struct mako_criteria_spec {
 	bool app_icon;
 	bool actionable;
 	bool expiring;
+	bool transient;
 	bool urgency;
 	bool category;
 	bool desktop_entry;

--- a/notification.c
+++ b/notification.c
@@ -36,6 +36,7 @@ void reset_notification(struct mako_notification *notif) {
 		free(action);
 	}
 
+	notif->transient = false;
 	notif->urgency = MAKO_NOTIFICATION_URGENCY_UNKNOWN;
 	notif->progress = -1;
 

--- a/notification.c
+++ b/notification.c
@@ -108,8 +108,7 @@ void destroy_notification(struct mako_notification *notif) {
 }
 
 void close_notification(struct mako_notification *notif,
-		enum mako_notification_close_reason reason,
-		bool add_to_history) {
+		enum mako_notification_close_reason reason) {
 	struct mako_state *state = notif->state;
 
 	notify_notification_closed(notif, reason);
@@ -132,7 +131,7 @@ void close_notification(struct mako_notification *notif,
 	destroy_timer(notif->timer);
 	notif->timer = NULL;
 
-	if (add_to_history) {
+	if (!notif->transient) {
 		wl_list_insert(&state->history, &notif->link);
 		while (wl_list_length(&state->history) > state->config.max_history) {
 			struct mako_notification *n =
@@ -171,13 +170,12 @@ struct mako_notification *get_tagged_notification(struct mako_state *state,
 }
 
 void close_group_notifications(struct mako_notification *top_notif,
-		enum mako_notification_close_reason reason,
-		bool add_to_history) {
+		enum mako_notification_close_reason reason) {
 	struct mako_state *state = top_notif->state;
 
 	if (top_notif->style.group_criteria_spec.none) {
 		// No grouping, just close the notification
-		close_notification(top_notif, reason, add_to_history);
+		close_notification(top_notif, reason);
 		return;
 	}
 
@@ -187,7 +185,7 @@ void close_group_notifications(struct mako_notification *top_notif,
 	struct mako_notification *notif, *tmp;
 	wl_list_for_each_safe(notif, tmp, &state->notifications, link) {
 		if (match_criteria(notif_criteria, notif)) {
-			close_notification(notif, reason, add_to_history);
+			close_notification(notif, reason);
 		}
 	}
 
@@ -195,11 +193,10 @@ void close_group_notifications(struct mako_notification *top_notif,
 }
 
 void close_all_notifications(struct mako_state *state,
-		enum mako_notification_close_reason reason,
-		bool add_to_history) {
+		enum mako_notification_close_reason reason) {
 	struct mako_notification *notif, *tmp;
 	wl_list_for_each_safe(notif, tmp, &state->notifications, link) {
-		close_notification(notif, reason, add_to_history);
+		close_notification(notif, reason);
 	}
 }
 
@@ -375,7 +372,7 @@ static void try_invoke_action(struct mako_notification *notif,
 			break;
 		}
 	}
-	close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, true);
+	close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
 }
 
 void notification_execute_binding(struct mako_notification *notif,
@@ -385,16 +382,20 @@ void notification_execute_binding(struct mako_notification *notif,
 	case MAKO_BINDING_NONE:
 		break;
 	case MAKO_BINDING_DISMISS:
-		close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, true);
+		notif->transient = false;
+		close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
 		break;
 	case MAKO_BINDING_DISMISS_NO_HISTORY:
-		close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, false);
+		notif->transient = true;
+		close_notification(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
 		break;
 	case MAKO_BINDING_DISMISS_GROUP:
-		close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED, true);
+		notif->transient = false;
+		close_group_notifications(notif, MAKO_NOTIFICATION_CLOSE_DISMISSED);
 		break;
 	case MAKO_BINDING_DISMISS_ALL:
-		close_all_notifications(notif->state, MAKO_NOTIFICATION_CLOSE_DISMISSED, true);
+		notif->transient = false;
+		close_all_notifications(notif->state, MAKO_NOTIFICATION_CLOSE_DISMISSED);
 		break;
 	case MAKO_BINDING_INVOKE_ACTION:
 		assert(binding->action_name != NULL);


### PR DESCRIPTION
Draft implementation for #541, implements handling of the "transient" hint according to the [Desktop Notifications Specification](https://specifications.freedesktop.org/notification-spec/latest-single/#hints).

The `-e`/`--transient` flag of `notify-send` (libnotify) allows a simple test:

```
notify-send -ea mailer -i email "from <test@example.org>" "Subject"
```

While users are still able to explicitly put notifications in the history when calling `makoctl dismiss` (without `--no-history`) or using the according binding (`MAKO_BINDING_DISMISS` instead of `MAKO_BINDING_DISMISS_NO_HISTORY`).

---

Second commit is some kind of a clean-up, as it doesn't make much sense, IMHO to maintain both, a transient member and a (no-)history parameter.