### PR TITLE
Add ability to scroll through group notifications

### DIFF
--- a/include/notification.h
+++ b/include/notification.h
@@ -30,6 +30,7 @@ struct mako_notification {
 	uint32_t id;
 	int group_index;
 	int group_count;
+	int group_focus_index;
 	bool hidden;
 
 	char *app_name;
@@ -100,6 +101,8 @@ size_t format_notification(struct mako_notification *notif, const char *format,
 	char *buf);
 void notification_handle_button(struct mako_notification *notif, uint32_t button,
 	enum wl_pointer_button_state state, const struct mako_binding_context *ctx);
+void notification_handle_axis(struct mako_notification *notif, uint32_t axis,
+	wl_fixed_t value, const struct mako_binding_context *ctx);
 void notification_handle_touch(struct mako_notification *notif,
 	const struct mako_binding_context *ctx);
 void notification_execute_binding(struct mako_notification *notif,

--- a/render.c
+++ b/render.c
@@ -394,7 +394,11 @@ void render(struct mako_surface *surface, struct pool_buffer *buffer, int scale,
 			continue;
 		}
 
-		if (style->invisible) {
+		if (style->invisible && notif->group_index != notif->group_focus_index) {
+			continue;
+		}
+
+		if (notif->group_index > -1 && notif->group_index != notif->group_focus_index) {
 			continue;
 		}
 


### PR DESCRIPTION
Hello,

I searched around a little but could not find the means to achieve the functionality that I was looking for, so I've added a way to scroll through group notifications using the mouse wheel.

I've tested it around a bit and it seems to work fine, but I understand that the way I've implemented it is probably not the best, so any further contribution would be much appreciated.

To-do:
- Add an option to disable, or make this functionality opt-in
- Make this work using a touchpad

Let me know what you think about this!