### PR TITLE
Use libsfdo-based symbolic/scalable/SVG icon lookup

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -8,6 +8,7 @@ packages:
   - pango-dev
   - gdk-pixbuf-dev
   - scdoc
+  - libsfdo
 sources:
   - https://github.com/emersion/mako
 tasks:

--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -8,7 +8,7 @@ packages:
   - pango-dev
   - gdk-pixbuf-dev
   - scdoc
-  - libsfdo
+  - libsfdo-dev
 sources:
   - https://github.com/emersion/mako
 tasks:

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -8,6 +8,7 @@ packages:
   - gdk-pixbuf2
   - scdoc
   - systemd
+  - libsfdo
 sources:
   - https://github.com/emersion/mako
 tasks:

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -13,7 +13,6 @@ packages:
   - scdoc
   - wayland
   - wayland-protocols
-  - libsfdo
 sources:
   - https://github.com/zeniko/libsfdo
   - https://github.com/emersion/mako

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -19,9 +19,15 @@ sources:
 tasks:
   - setup: |
       cd libsfdo
-      meson setup build/
+      meson setup build/ --prefix=$PWD/../local
       ninja -C build/
       ninja -C build/ install
+
+      export PKG_CONFIG_PATH="$PWD/../local/libdata/pkgconfig:/usr/local/libdata/pkgconfig:$PKG_CONFIG_PATH"
+      export LD_LIBRARY_PATH="$PWD/../local/lib:$LD_LIBRARY_PATH"
+      export CFLAGS="-I$PWD/../local/include $CFLAGS"
+      export LDFLAGS="-L$PWD/../local/lib $LDFLAGS"
+
       cd ../mako
       meson build/ -Dauto_features=enabled -Dsd-bus-provider=basu
   - build: |

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -14,7 +14,7 @@ packages:
   - wayland
   - wayland-protocols
 sources:
-  - https://github.com/zeniko/libsfdo
+  - https://gitlab.freedesktop.org/vyivel/libsfdo
   - https://github.com/emersion/mako
 tasks:
   - setup: |

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -10,6 +10,7 @@ packages:
   - scdoc
   - wayland
   - wayland-protocols
+  - libsfdo
 sources:
   - https://github.com/emersion/mako
 tasks:

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -3,8 +3,11 @@ packages:
   - basu
   - evdev-proto
   - gdk-pixbuf2
+  - git
+  - glib
   - libepoll-shim
   - meson
+  - ninja
   - pango
   - pkgconf
   - scdoc
@@ -12,10 +15,15 @@ packages:
   - wayland-protocols
   - libsfdo
 sources:
+  - https://github.com/zeniko/libsfdo
   - https://github.com/emersion/mako
 tasks:
   - setup: |
-      cd mako
+      cd libsfdo
+      meson setup build/
+      ninja -C build/
+      ninja -C build/ install
+      cd ../mako
       meson build/ -Dauto_features=enabled -Dsd-bus-provider=basu
   - build: |
       cd mako

--- a/include/config.h
+++ b/include/config.h
@@ -41,7 +41,7 @@ enum mako_icon_location {
 struct mako_style_spec {
 	bool width, height, outer_margin, margin, padding, border_size, border_radius, font,
 		markup, format, text_alignment, actions, default_timeout, ignore_timeout,
-		icons, max_icon_size, icon_path, icon_border_radius, group_criteria_spec, invisible, history,
+		icons, max_icon_size, icon_path, icon_theme, icon_border_radius, group_criteria_spec, invisible, history,
 		icon_location, max_visible, layer, output, anchor;
 	struct {
 		bool background, text, border, progress;
@@ -67,6 +67,7 @@ struct mako_style {
 	bool icons;
 	int32_t max_icon_size;
 	char *icon_path;
+	char *icon_theme;
 	int32_t icon_border_radius;
 
 	char *font;

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,8 @@ realtime = cc.find_library('rt')
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.32')
 wayland_cursor = dependency('wayland-cursor')
+sfdo_basedir = dependency('libsfdo-basedir')
+sfdo_icon = dependency('libsfdo-icon')
 
 epoll = dependency('', required: false)
 if (not cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>') or
@@ -94,6 +96,8 @@ executable(
 		realtime,
 		wayland_client,
 		wayland_cursor,
+		sfdo_basedir,
+		sfdo_icon,
 	],
 	include_directories: [mako_inc],
 	install: true,


### PR DESCRIPTION
This PR introduces native Freedesktop Icon Theme support in Mako by leveraging libsfdo for scalable (.svg) and high-DPI icons. Previously, Mako only searched for bitmap icons under hard-coded icon-path directories. Now, users can specify one or more icon themes (e.g. Adwaita:Tela-green-dark) in their configuration, and Mako will:

1. First attempt to resolve the notification’s icon_path through libsfdo using the configured theme names.
2. Then, if no icon is found via libsfdo, fall back to the existing icon-path lookup logic (unchanged).

Changes:

- New icon-theme config key
Accepts a colon-separated list of Freedesktop icon theme names.
Example:
```ini
icon-theme = Adwaita:Tela-green-dark
icon-path = /usr/share/icons/Papirus # fall back
max-icon-size = 48
```

- libsfdo integration
Create and configure an sfdo_icon_lookup context using the user’s icon-theme list.
Set desired icon size, output scale, and fallback theme (hicolor) via libsfdo.
Call sfdo_icon_theme_lookup() to fetch scalable and SVG icons.

- Fallback behavior
If icon-theme is unset or libsfdo lookup fails, Mako reverts to its original icon-path + glob() search logic without any changes.

- No breaking changes for users who don’t set icon-theme; existing behavior is preserved.

Testing:

- Verified that SVG and high-DPI icons are correctly resolved when icon-theme is set.
- Confirmed that bitmap (.png, .xpm) icons in icon-path still load when no matching theme icon exists.
- Manual tests across Wayland outputs with scale factors 1 and 2.

Closes #555
CC: @arebaka