### PR TITLE
Add support for override.* keys in to apply property overrides after matching criterias

### DIFF
--- a/criteria.c
+++ b/criteria.c
@@ -14,6 +14,7 @@
 #include "notification.h"
 #include "surface.h"
 #include "wayland.h"
+#include "styling.h"
 
 struct mako_criteria *create_criteria(struct mako_config *config) {
 	struct mako_criteria *criteria = calloc(1, sizeof(struct mako_criteria));
@@ -432,7 +433,7 @@ ssize_t apply_each_criteria(struct wl_list *criteria_list,
 		}
 		++match_count;
 
-		if (!apply_style(&notif->style, &criteria->style)) {
+		if (!apply_style(notif, &criteria->style)) {
 			return -1;
 		}
 	}

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -442,9 +442,9 @@ static int handle_set_modes(sd_bus_message *msg, void *data,
 }
 
 static int get_modes(sd_bus *bus, const char *path,
-			 const char *interface, const char *property,
-			 sd_bus_message *reply, void *data,
-			 sd_bus_error *ret_error) {
+		const char *interface, const char *property,
+		sd_bus_message *reply, void *data,
+		sd_bus_error *ret_error) {
 	struct mako_state *state = data;
 
 	int ret = sd_bus_message_open_container(reply, 'a', "s");
@@ -474,9 +474,9 @@ void emit_modes_changed(struct mako_state *state) {
 
 
 static int get_notifications(sd_bus *bus, const char *path,
-			 const char *interface, const char *property,
-			 sd_bus_message *reply, void *data,
-			 sd_bus_error *ret_error) {
+		const char *interface, const char *property,
+		sd_bus_message *reply, void *data,
+		sd_bus_error *ret_error) {
 	struct mako_state *state = data;
 
 	int ret = handle_list_for_each(reply, &state->notifications);

--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -10,6 +10,7 @@
 #include "mode.h"
 #include "notification.h"
 #include "wayland.h"
+#include "styling.h"
 
 static const char *service_path = "/fr/emersion/Mako";
 static const char *service_interface = "fr.emersion.Mako";
@@ -441,9 +442,9 @@ static int handle_set_modes(sd_bus_message *msg, void *data,
 }
 
 static int get_modes(sd_bus *bus, const char *path,
-		     const char *interface, const char *property,
-		     sd_bus_message *reply, void *data,
-		     sd_bus_error *ret_error) {
+			 const char *interface, const char *property,
+			 sd_bus_message *reply, void *data,
+			 sd_bus_error *ret_error) {
 	struct mako_state *state = data;
 
 	int ret = sd_bus_message_open_container(reply, 'a', "s");
@@ -473,9 +474,9 @@ void emit_modes_changed(struct mako_state *state) {
 
 
 static int get_notifications(sd_bus *bus, const char *path,
-		     const char *interface, const char *property,
-		     sd_bus_message *reply, void *data,
-		     sd_bus_error *ret_error) {
+			 const char *interface, const char *property,
+			 sd_bus_message *reply, void *data,
+			 sd_bus_error *ret_error) {
 	struct mako_state *state = data;
 
 	int ret = handle_list_for_each(reply, &state->notifications);

--- a/include/config.h
+++ b/include/config.h
@@ -7,6 +7,7 @@
 #include <pango/pango.h>
 #include "types.h"
 
+
 enum mako_binding_action {
 	MAKO_BINDING_NONE,
 	MAKO_BINDING_DISMISS,
@@ -21,6 +22,17 @@ struct mako_binding {
 	enum mako_binding_action action;
 	char *command;     // for MAKO_BINDING_EXEC
 	char *action_name; // for MAKO_BINDING_INVOKE_ACTION
+};
+
+struct mako_override {
+	char *app_name;
+	char *app_icon;
+	char *category;
+	char *desktop_entry;
+	char *summary;
+	char *body;
+	enum mako_notification_urgency urgency;
+	int32_t timeout;
 };
 
 enum mako_sort_criteria {
@@ -50,6 +62,9 @@ struct mako_style_spec {
 		bool left, right, middle;
 	} button_bindings;
 	bool touch_binding, notify_binding;
+	struct {
+		bool app_name, app_icon, category, desktop_entry, summary, body, urgency, timeout;
+	} override;
 };
 
 
@@ -100,6 +115,8 @@ struct mako_style {
 		struct mako_binding left, right, middle;
 	} button_bindings;
 	struct mako_binding touch_binding, notify_binding;
+
+	struct mako_override override;
 };
 
 struct mako_config {
@@ -116,13 +133,6 @@ struct mako_config {
 
 void init_default_config(struct mako_config *config);
 void finish_config(struct mako_config *config);
-
-void init_default_style(struct mako_style *style);
-void init_empty_style(struct mako_style *style);
-void finish_style(struct mako_style *style);
-bool apply_style(struct mako_style *target, const struct mako_style *style);
-bool apply_superset_style(
-		struct mako_style *target, struct mako_config *config);
 
 int parse_config_arguments(struct mako_config *config, int argc, char **argv);
 int load_config_file(struct mako_config *config, char *config_arg);

--- a/include/styling.h
+++ b/include/styling.h
@@ -1,0 +1,14 @@
+#ifndef MAKO_STYLING_H
+#define MAKO_STYLING_H
+
+#include "config.h"
+#include "notification.h"
+
+void init_default_style(struct mako_style *style);
+void init_empty_style(struct mako_style *style);
+void finish_style(struct mako_style *style);
+bool apply_style(struct mako_notification *notif, const struct mako_style *style);
+bool apply_superset_style(
+		struct mako_style *target, struct mako_config *config);
+
+#endif

--- a/notification.c
+++ b/notification.c
@@ -19,6 +19,7 @@
 #include "icon.h"
 #include "string-util.h"
 #include "wayland.h"
+#include "styling.h"
 
 bool hotspot_at(struct mako_hotspot *hotspot, int32_t x, int32_t y) {
 	return x >= hotspot->x &&


### PR DESCRIPTION
This pull request introduces a new “overrides” mechanism in Mako’s INI-style configuration. Users can now specify one or more override.* keys inside a criteria block to defer certain property assignments until after all matching criteria have been evaluated.

Closes #566
Ref #559
Ref #211
CC: @arebaka