### PR TITLE
Fix grayscale antialiasing for compositors reporting unknown subpixel layout

### DIFF
--- a/render.c
+++ b/render.c
@@ -84,7 +84,8 @@ static void set_font_options(cairo_t *cairo, struct mako_surface *surface) {
 	}
 
 	cairo_font_options_t *fo = cairo_font_options_create();
-	if (surface->surface_output->subpixel == WL_OUTPUT_SUBPIXEL_NONE) {
+	if (surface->surface_output->subpixel == WL_OUTPUT_SUBPIXEL_NONE ||
+	    surface->surface_output->subpixel == WL_OUTPUT_SUBPIXEL_UNKNOWN) {
 		cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_GRAY);
 	} else {
 		cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_SUBPIXEL);


### PR DESCRIPTION
Hyprand and some other Wayland compositors report WL_OUTPUT_SUBPIXEL_UNKNOWN instead of WL_OUTPUT_SUBPIXEL_NONE for displays where subpixel rendering is not applicable or unknown. This caused mako to incorrectly use subpixel antialiasing even when the user has configured their system for grayscale antialiasing through fontconfig.

The previous logic only checked for WL_OUTPUT_SUBPIXEL_NONE to trigger grayscale antialiasing, causing WL_OUTPUT_SUBPIXEL_UNKNOWN (value 0) to fall through to the subpixel antialiasing branch.

This fix treats both UNKNOWN and NONE subpixel values as requiring grayscale antialiasing, which is the safer default when the subpixel layout cannot be determined. This respects user preferences for grayscale rendering and avoids unwanted color fringing on displays where subpixel information is unavailable.

Tested on Hyprland with Samsung Odyssey G95NC display reporting unknown subpixel orientation.
