### PR TITLE
Remove criteria for max_visible (Fix #413)

### DIFF
--- a/criteria.c
+++ b/criteria.c
@@ -526,12 +526,6 @@ bool validate_criteria(struct mako_criteria *criteria) {
 	copy.hidden = false;
 	bool any_but_surface = mako_criteria_spec_any(&copy);
 
-	if (criteria->style.max_visible && any_but_surface) {
-		fprintf(stderr, "Setting `max_visible` is allowed only for `output` "
-				"and/or `anchor`\n");
-		return false;
-	}
-
 	// Hidden is almost always specified, need to look at the actual value.
 	if (criteria->hidden && any_but_surface) {
 		fprintf(stderr, "Can only set `hidden` along with `output` "


### PR DESCRIPTION
Fix for https://github.com/emersion/mako/issues/413

I'm not sure if this breaks anything, but it fixes an error when trying to use max_visible under a criteria section.

After this fix exceeding the max visible number of notifications by n will still create a new notification that says "(n more)"

As a workaround, create a criteria like so to make these overflowing notifications invisible:
```
[hidden]
invisible=1
```