### PR TITLE
Add cut corners popup style

### DIFF
--- a/config.c
+++ b/config.c
@@ -91,6 +91,11 @@ void init_default_style(struct mako_style *style) {
 	style->border_radius.bottom = 0;
 	style->border_radius.left = 0;
 
+	style->border_cut.top = 0;
+	style->border_cut.right = 0;
+	style->border_cut.bottom = 0;
+	style->border_cut.left = 0;
+
 	style->border_size = 2;
 
 #ifdef HAVE_ICONS
@@ -356,6 +361,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 		target->spec.border_radius = true;
 	}
 
+	if (style->spec.border_cut) {
+		target->border_cut = style->border_cut;
+		target->spec.border_cut = true;
+	}
+
 	if (style->spec.output) {
 		free(target->output);
 		target->output = new_output;
@@ -463,6 +473,10 @@ bool apply_superset_style(
 		target->border_radius.bottom =
 			max(style->border_radius.bottom, target->border_radius.bottom);
 		target->border_radius.left = max(style->border_radius.left, target->border_radius.left);
+		target->border_cut.top = max(style->border_cut.top, target->border_cut.top);
+		target->border_cut.right = max(style->border_cut.right, target->border_cut.right);
+		target->border_cut.bottom = max(style->border_cut.bottom, target->border_cut.bottom);
+		target->border_cut.left = max(style->border_cut.left, target->border_cut.left);
 		target->border_size = max(style->border_size, target->border_size);
 		target->icons = style->icons || target->icons;
 		target->max_icon_size = max(style->max_icon_size, target->max_icon_size);
@@ -656,6 +670,8 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 			style->padding.right = max(style->border_radius.right, style->padding.right);
 		}
 		return spec->border_radius;
+	} else if (strcmp(name, "border-cut") == 0) {
+		return spec->border_cut = parse_directional(value, &style->border_cut);
 	} else if (strcmp(name, "max-visible") == 0) {
 		return style->spec.max_visible = parse_int(value, &style->max_visible);
 	} else if (strcmp(name, "output") == 0) {
@@ -907,6 +923,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"border-size", required_argument, 0, 0},
 		{"border-color", required_argument, 0, 0},
 		{"border-radius", required_argument, 0, 0},
+		{"border-cut", required_argument, 0, 0},
 		{"progress-color", required_argument, 0, 0},
 		{"icons", required_argument, 0, 0},
 		{"icon-location", required_argument, 0, 0},

--- a/doc/mako.5.scd
+++ b/doc/mako.5.scd
@@ -182,6 +182,12 @@ Supported actions:
 
 	Default: 0
 
+*border-cut*=_directional_
+	Set popup corner rounding style to diagonal cut if not zero. See
+	*DIRECTIONAL VALUES* for more information.
+
+	Default: 0
+
 *progress-color*=[over|source] _color_
 	Set popup progress indicator color to _color_. See *COLOR* for more
 	information. To draw the progress indicator on top of the background

--- a/include/config.h
+++ b/include/config.h
@@ -39,7 +39,7 @@ enum mako_icon_location {
 // fields in the mako_style structure should have a counterpart here. Inline
 // structs are also mirrored.
 struct mako_style_spec {
-	bool width, height, outer_margin, margin, padding, border_size, border_radius, font,
+	bool width, height, outer_margin, margin, padding, border_size, border_radius, border_cut, font,
 		markup, format, text_alignment, actions, default_timeout, ignore_timeout,
 		icons, max_icon_size, icon_path, icon_border_radius, group_criteria_spec, invisible, history,
 		icon_location, max_visible, layer, output, anchor;
@@ -62,6 +62,7 @@ struct mako_style {
 	struct mako_directional margin;
 	struct mako_directional padding;
 	struct mako_directional border_radius;
+	struct mako_directional border_cut;
 	int32_t border_size;
 
 	bool icons;


### PR DESCRIPTION
This adds an option to display corners as diagonally cut instead of rounded.

<img width="381" height="119" alt="Screenshot from 2025-11-29 19-30-49" src="https://github.com/user-attachments/assets/ad774111-9354-4eb2-9f76-73cd3d459d8b" />
