### PR TITLE
Add OpenRC user init scrpt

### DIFF
--- a/contrib/openrc-user.init
+++ b/contrib/openrc-user.init
@@ -1,0 +1,25 @@
+#!/sbin/openrc-run
+
+description="Lightweight Wayland notification daemon"
+
+supervisor="supervise-daemon"
+command="/usr/bin/mako"
+
+depend() {
+	after dbus
+	provide notification-daemon
+}
+
+start_pre() {
+	if [ -z "$WAYLAND_DISPLAY" ]; then
+		eerror "\$WAYLAND_DISPLAY unset, can't proceed."
+		return 1
+	fi
+}
+
+extra_started_commands="reload"
+description_reload="Reload mako configuration using makoctl"
+reload() {
+	makoctl reload
+	eend $? "Reloaded mako configuration"
+}


### PR DESCRIPTION
OpenRC supports user services since 0.60.
This commit adds a simple service script that mimics what the systemd service is doing.

Wrote & tested on Gentoo, inspired by gui-apps/foot's.

Please note that checking $WAYLAND_SESSION requires `rc_env_allow=WAYLAND_DISPLAY` to be set in user's `/rc.conf`

Closes: https://github.com/emersion/mako/issues/614