### PR TITLE
openrc-user.init: need dbus

### DIFF
--- a/contrib/openrc-user.init
+++ b/contrib/openrc-user.init
@@ -6,7 +6,7 @@ supervisor="supervise-daemon"
 command="/usr/bin/mako"
 
 depend() {
-	after dbus
+	need dbus
 	provide notification-daemon
 }
 


### PR DESCRIPTION
`after dbus` did not launch dbus, which is required.
`want` could be used but since there is no reason for mako to be running without it so we also make it stop if it's not there.