### PR TITLE
Add ignore-replace and ignore-close options

### DIFF
--- a/config.c
+++ b/config.c
@@ -110,6 +110,7 @@ void init_default_style(struct mako_style *style) {
 	style->actions = true;
 	style->default_timeout = 0;
 	style->ignore_timeout = false;
+	style->ignore_replace = false;
 
 	style->colors.background = 0x285577FF;
 	style->colors.text = 0xFFFFFFFF;
@@ -309,6 +310,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 	if (style->spec.ignore_timeout) {
 		target->ignore_timeout = style->ignore_timeout;
 		target->spec.ignore_timeout = true;
+	}
+
+	if (style->spec.ignore_replace) {
+		target->ignore_replace = style->ignore_replace;
+		target->spec.ignore_replace = true;
 	}
 
 	if (style->spec.colors.background) {
@@ -642,6 +648,9 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	} else if (strcmp(name, "ignore-timeout") == 0) {
 		return spec->ignore_timeout =
 			parse_boolean(value, &style->ignore_timeout);
+	} else if (strcmp(name, "ignore-replace") == 0) {
+		return spec->ignore_replace =
+			parse_boolean(value, &style->ignore_replace);
 	} else if (strcmp(name, "group-by") == 0) {
 		return spec->group_criteria_spec =
 			parse_criteria_spec(value, &style->group_criteria_spec);
@@ -921,6 +930,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"history", required_argument, 0, 0},
 		{"default-timeout", required_argument, 0, 0},
 		{"ignore-timeout", required_argument, 0, 0},
+		{"ignore-replace", required_argument, 0, 0},
 		{"output", required_argument, 0, 0},
 		{"layer", required_argument, 0, 0},
 		{"anchor", required_argument, 0, 0},

--- a/config.c
+++ b/config.c
@@ -111,6 +111,7 @@ void init_default_style(struct mako_style *style) {
 	style->default_timeout = 0;
 	style->ignore_timeout = false;
 	style->ignore_replace = false;
+	style->ignore_close = false;
 
 	style->colors.background = 0x285577FF;
 	style->colors.text = 0xFFFFFFFF;
@@ -315,6 +316,11 @@ bool apply_style(struct mako_style *target, const struct mako_style *style) {
 	if (style->spec.ignore_replace) {
 		target->ignore_replace = style->ignore_replace;
 		target->spec.ignore_replace = true;
+	}
+
+	if (style->spec.ignore_close) {
+		target->ignore_close = style->ignore_close;
+		target->spec.ignore_close = true;
 	}
 
 	if (style->spec.colors.background) {
@@ -651,6 +657,9 @@ static bool apply_style_option(struct mako_style *style, const char *name,
 	} else if (strcmp(name, "ignore-replace") == 0) {
 		return spec->ignore_replace =
 			parse_boolean(value, &style->ignore_replace);
+	} else if (strcmp(name, "ignore-close") == 0) {
+		return spec->ignore_close =
+			parse_boolean(value, &style->ignore_close);
 	} else if (strcmp(name, "group-by") == 0) {
 		return spec->group_criteria_spec =
 			parse_criteria_spec(value, &style->group_criteria_spec);
@@ -931,6 +940,7 @@ int parse_config_arguments(struct mako_config *config, int argc, char **argv) {
 		{"default-timeout", required_argument, 0, 0},
 		{"ignore-timeout", required_argument, 0, 0},
 		{"ignore-replace", required_argument, 0, 0},
+		{"ignore-close", required_argument, 0, 0},
 		{"output", required_argument, 0, 0},
 		{"layer", required_argument, 0, 0},
 		{"anchor", required_argument, 0, 0},

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -106,6 +106,9 @@ static int handle_notify(sd_bus_message *msg, void *data,
 	struct mako_notification *notif = NULL;
 	if (replaces_id > 0) {
 		notif = get_notification(state, replaces_id);
+		if (notif && notif->style.ignore_replace) {
+			notif = NULL;
+		}
 	}
 
 	if (notif) {
@@ -362,7 +365,7 @@ static int handle_notify(sd_bus_message *msg, void *data,
 	if (notif->tag) {
 		// Find and replace the existing notfication with a matching tag
 		struct mako_notification *replace_notif = get_tagged_notification(state, notif->tag, app_name);
-		if (replace_notif) {
+		if (replace_notif && !replace_notif->style.ignore_replace) {
 			notif->id = replace_notif->id;
 			wl_list_insert(&replace_notif->link, &notif->link);
 			destroy_notification(replace_notif);
@@ -446,7 +449,7 @@ static int handle_close_notification(sd_bus_message *msg, void *data,
 
 	// TODO: check client
 	struct mako_notification *notif = get_notification(state, id);
-	if (notif) {
+	if (notif && !notif->style.ignore_replace) {
 		struct mako_surface *surface = notif->surface;
 		close_notification(notif, MAKO_NOTIFICATION_CLOSE_REQUEST, true);
 		set_dirty(surface);

--- a/dbus/xdg.c
+++ b/dbus/xdg.c
@@ -449,10 +449,14 @@ static int handle_close_notification(sd_bus_message *msg, void *data,
 
 	// TODO: check client
 	struct mako_notification *notif = get_notification(state, id);
-	if (notif && !notif->style.ignore_replace) {
-		struct mako_surface *surface = notif->surface;
-		close_notification(notif, MAKO_NOTIFICATION_CLOSE_REQUEST, true);
-		set_dirty(surface);
+	if (notif) {
+		if (notif->style.ignore_close) {
+			notify_notification_closed(notif, MAKO_NOTIFICATION_CLOSE_REQUEST);
+		} else {
+			struct mako_surface *surface = notif->surface;
+			close_notification(notif, MAKO_NOTIFICATION_CLOSE_REQUEST, true);
+			set_dirty(surface);
+		}
 	}
 
 	return sd_bus_reply_method_return(msg, "");

--- a/doc/mako.5.scd
+++ b/doc/mako.5.scd
@@ -274,6 +274,20 @@ Default when grouped: (%g) <b>%s</b>\\n%b
 
 	Default: 0
 
+*ignore-replace*=0|1
+	If set, mako will ignore requests from applications to replace an existing
+	notification. The replacement notification will be shown as a new, separate
+	notification. Note that some apps replace their notifications by closing
+	the previous one; in that case use _ignore-close_ instead.
+
+	Default: 0
+
+*ignore-close*=0|1
+	If set, mako will ignore requests from applications to close a notification
+	via a D-Bus call.
+
+	Default: 0
+
 *group-by*=_field[,field,...]_
 	A comma-separated list of criteria fields that will be compared to other
 	visible notifications to determine if this one should form a group with

--- a/include/config.h
+++ b/include/config.h
@@ -40,7 +40,7 @@ enum mako_icon_location {
 // structs are also mirrored.
 struct mako_style_spec {
 	bool width, height, outer_margin, margin, padding, border_size, border_radius, font,
-		markup, format, text_alignment, actions, default_timeout, ignore_timeout,
+		markup, format, text_alignment, actions, default_timeout, ignore_timeout, ignore_replace,
 		icons, max_icon_size, icon_path, icon_border_radius, group_criteria_spec, invisible, history,
 		icon_location, max_visible, layer, output, anchor;
 	struct {
@@ -77,6 +77,7 @@ struct mako_style {
 	bool actions;
 	int default_timeout; // in ms
 	bool ignore_timeout;
+	bool ignore_replace;
 
 	struct {
 		uint32_t background;

--- a/include/config.h
+++ b/include/config.h
@@ -40,7 +40,7 @@ enum mako_icon_location {
 // structs are also mirrored.
 struct mako_style_spec {
 	bool width, height, outer_margin, margin, padding, border_size, border_radius, font,
-		markup, format, text_alignment, actions, default_timeout, ignore_timeout, ignore_replace,
+		markup, format, text_alignment, actions, default_timeout, ignore_timeout, ignore_replace, ignore_close,
 		icons, max_icon_size, icon_path, icon_border_radius, group_criteria_spec, invisible, history,
 		icon_location, max_visible, layer, output, anchor;
 	struct {
@@ -78,6 +78,7 @@ struct mako_style {
 	int default_timeout; // in ms
 	bool ignore_timeout;
 	bool ignore_replace;
+	bool ignore_close;
 
 	struct {
 		uint32_t background;


### PR DESCRIPTION
config: add ignore-replace and ignore-close options
Adds ignore-replace and ignore-close options to ignore applications request to replace or close their old notifications, similarly to how ignore-timeout ignores the timeout sent by applications. Useful for apps like discord that always replace older messages with new ones, making it possible to see only the latest one (this is not a bug on discord side, just intended behavior which users may want to overwrite/ignore the same way ignore-timeout allows it). Per-criteria overrides also work.

Closes #561