### PR TITLE
fix use-after-free crash in handle_restore_action

### DIFF
--- a/dbus/mako.c
+++ b/dbus/mako.c
@@ -129,6 +129,10 @@ static int handle_restore_action(sd_bus_message *msg, void *data,
 		wl_container_of(state->history.next, notif, link);
 	wl_list_remove(&notif->link);
 
+	finish_style(&notif->style);
+	init_empty_style(&notif->style);
+	apply_each_criteria(&state->config.criteria, notif);
+
 	insert_notification(state, notif);
 	set_dirty(notif->surface);
 

--- a/notification.c
+++ b/notification.c
@@ -132,6 +132,7 @@ void close_notification(struct mako_notification *notif,
 	notif->timer = NULL;
 
 	if (add_to_history) {
+		notif->surface = NULL;
 		wl_list_insert(&state->history, &notif->link);
 		while (wl_list_length(&state->history) > state->config.max_history) {
 			struct mako_notification *n =


### PR DESCRIPTION
notif->surface holds a pointer to the mako_surface that was displaying the notification when it was moved to history. That surface may have since been destroyed and freed (eg. it was torn down when all visible notifications expired). Calling set_dirty() on the stale pointer causes a segfault.

Fix this by resetting notif->surface and re-applying criteria before reinserting the notification, mirroring the pattern used in reapply_config().

tested locally in various scenarios and haven't been able to reproduce segfaults from frequent restore/dismiss actions once this is applied!