### PR TITLE
Destroy frame_callback when tearing down surface in send_frame

### DIFF
--- a/wayland.c
+++ b/wayland.c
@@ -619,6 +619,10 @@ static void send_frame(struct mako_surface *surface) {
 			zwlr_layer_surface_v1_destroy(surface->layer_surface);
 			surface->layer_surface = NULL;
 		}
+		if (surface->frame_callback != NULL) {
+			wl_callback_destroy(surface->frame_callback);
+			surface->frame_callback = NULL;
+		}
 		if (surface->surface != NULL) {
 			wl_surface_destroy(surface->surface);
 			surface->surface = NULL;


### PR DESCRIPTION
When send_frame() tears down the wl_surface (height == 0, or output change), any pending frame_callback is left intact. 

If a frame callback on a destroyed surface isnt delivered, frame_callback remains non-null, and `schedule_frame_and_commit()` will shortcircuit indefinitely, blocking all future redraws for that surface

Basically mako would restore "ghost" notifications from history

`layer_surface_handle_closed()` already handles this correctly, so I mirrored that cleanup in the send_frame() teardown path here