### PR TITLE
Refactor cairo scale

### DIFF
--- a/icon.c
+++ b/icon.c
@@ -296,10 +296,18 @@ struct mako_icon *create_icon(struct mako_notification *notif) {
 void draw_icon(cairo_t *cairo, struct mako_icon *icon,
 		double xpos, double ypos) {
 	cairo_save(cairo);
+	// used translate here to get to the position
 	cairo_translate(cairo, xpos, ypos);
 	cairo_scale(cairo,icon->scale, icon->scale);
 	cairo_set_source_surface(cairo, icon->image, 0, 0);
-	// cairo_paint(cairo);
+
+	/*
+	 * used mask_surface instead of paint because
+	 * it was causing a weird box behind icons
+	 * and when passed through spam testing some parts
+	 * of icons were becoming trasparent (see through).
+	*/
+
 	cairo_mask_surface(cairo, icon->image, 0, 0);
 	cairo_restore(cairo);
 }

--- a/icon.c
+++ b/icon.c
@@ -294,11 +294,13 @@ struct mako_icon *create_icon(struct mako_notification *notif) {
 #endif
 
 void draw_icon(cairo_t *cairo, struct mako_icon *icon,
-		double xpos, double ypos, double scale) {
+		double xpos, double ypos) {
 	cairo_save(cairo);
-	cairo_scale(cairo, scale*icon->scale, scale*icon->scale);
-	cairo_set_source_surface(cairo, icon->image, xpos/icon->scale, ypos/icon->scale);
-	cairo_paint(cairo);
+	cairo_translate(cairo, xpos, ypos);
+	cairo_scale(cairo,icon->scale, icon->scale);
+	cairo_set_source_surface(cairo, icon->image, 0, 0);
+	// cairo_paint(cairo);
+	cairo_mask_surface(cairo, icon->image, 0, 0);
 	cairo_restore(cairo);
 }
 

--- a/include/icon.h
+++ b/include/icon.h
@@ -25,6 +25,6 @@ struct mako_image_data {
 struct mako_icon *create_icon(struct mako_notification *notif);
 void destroy_icon(struct mako_icon *icon);
 void draw_icon(cairo_t *cairo, struct mako_icon *icon,
-		double xpos, double ypos, double scale);
+		double xpos, double ypos);
 
 #endif

--- a/render.c
+++ b/render.c
@@ -25,30 +25,21 @@ static void set_source_u32(cairo_t *cairo, uint32_t color) {
 		(color >> (0*8) & 0xFF) / 255.0);
 }
 
-static void set_layout_size(PangoLayout *layout, int width, int height,
-		int scale) {
-	pango_layout_set_width(layout, width * scale * PANGO_SCALE);
-	pango_layout_set_height(layout, height * scale * PANGO_SCALE);
+static void set_layout_size(PangoLayout *layout, int width, int height) {
+	pango_layout_set_width(layout, width * PANGO_SCALE);
+	pango_layout_set_height(layout, height * PANGO_SCALE);
 }
 
-static void move_to(cairo_t *cairo, double x, double y, int scale) {
-	cairo_move_to(cairo, x * scale, y * scale);
+static void move_to(cairo_t *cairo, double x, double y) {
+	cairo_move_to(cairo, x, y);
 }
 
-static void set_rounded_rectangle(cairo_t *cairo, double x, double y, double width, double height,
-		int scale, int radius_top_left, int radius_top_right, int radius_bottom_right, int radius_bottom_left) {
+static void set_rounded_rectangle(cairo_t *cairo, double x, double y, double width, double height, int radius_top_left, int radius_top_right, int radius_bottom_right, int radius_bottom_left) {
 	if (width == 0 || height == 0) {
 		return;
 	}
-	x *= scale;
-	y *= scale;
-	width *= scale;
-	height *= scale;
-	radius_top_left *= scale;
-	radius_top_right *= scale;
-	radius_bottom_right *= scale;
-	radius_bottom_left *= scale;
-	double degrees = M_PI / 180.0;
+
+		double degrees = M_PI / 180.0;
 
 	cairo_new_sub_path(cairo);
 
@@ -97,7 +88,7 @@ static void set_font_options(cairo_t *cairo, struct mako_surface *surface) {
 }
 
 static int render_notification(cairo_t *cairo, struct mako_state *state, struct mako_surface *surface,
-		struct mako_style *style, const char *text, struct mako_icon *icon, int offset_y, int scale,
+		struct mako_style *style, const char *text, struct mako_icon *icon, int offset_y,
 		struct mako_hotspot *hotspot, int progress) {
 	int border_size = 2 * style->border_size;
 	int padding_height = style->padding.top + style->padding.bottom;
@@ -152,7 +143,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 	set_font_options(cairo, surface);
 
 	PangoLayout *layout = pango_cairo_create_layout(cairo);
-	set_layout_size(layout, text_layout_width, text_layout_height, scale);
+	set_layout_size(layout, text_layout_width, text_layout_height);
 	pango_layout_set_alignment(layout, style->text_alignment);
 	pango_layout_set_wrap(layout, PANGO_WRAP_WORD_CHAR);
 	pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
@@ -177,7 +168,6 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 	if (attrs == NULL) {
 		attrs = pango_attr_list_new();
 	}
-	pango_attr_list_insert(attrs, pango_attr_scale_new(scale));
 	pango_layout_set_attributes(layout, attrs);
 	pango_attr_list_unref(attrs);
 
@@ -189,8 +179,8 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 	if (pango_layout_get_character_count(layout) > 0) {
 		pango_layout_get_pixel_size(layout, &buffer_text_width, &buffer_text_height);
 	}
-	int text_height = buffer_text_height / scale;
-	int text_width = buffer_text_width / scale;
+	int text_height = buffer_text_height ;
+	int text_width = buffer_text_width ;
 
 	if (text_height > text_layout_height) {
 		text_height = text_layout_height;
@@ -222,7 +212,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 		offset_y + style->border_size / 2.0,
 		notif_background_width,
 		notif_height - style->border_size,
-		scale, radius_top_left, radius_top_right, radius_bottom_right, radius_bottom_left);
+	  radius_top_left, radius_top_right, radius_bottom_right, radius_bottom_left);
 
 	// Render background, keeping the path.
 	set_source_u32(cairo, style->colors.background);
@@ -253,7 +243,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 			offset_y + style->border_size,
 			progress_width,
 			notif_height - style->border_size,
-			scale, 0, 0, 0, 0);
+			 0, 0, 0, 0);
 	cairo_fill(cairo);
 	cairo_restore(cairo);
 
@@ -265,7 +255,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 	cairo_append_path(cairo, border_path);
 	set_source_u32(cairo, style->colors.border);
 	cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
-	cairo_set_line_width(cairo, style->border_size * scale);
+	cairo_set_line_width(cairo, style->border_size );
 	cairo_stroke(cairo);
 	cairo_restore(cairo);
 
@@ -303,9 +293,9 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 			break;
 		}
 		cairo_save(cairo);
-		set_rounded_rectangle(cairo, xpos, ypos, icon->width, icon->height, scale, icon_radius, icon_radius, icon_radius, icon_radius);
+		set_rounded_rectangle(cairo, xpos, ypos, icon->width, icon->height, icon_radius, icon_radius, icon_radius, icon_radius);
 		cairo_clip(cairo);
-		draw_icon(cairo, icon, xpos, ypos, scale);
+		draw_icon(cairo, icon, xpos, ypos);
 		cairo_restore(cairo);
 	}
 
@@ -319,8 +309,7 @@ static int render_notification(cairo_t *cairo, struct mako_state *state, struct 
 	set_source_u32(cairo, style->colors.text);
 	move_to(cairo,
 		offset_x + style->border_size + text_x,
-		offset_y + style->border_size + text_y,
-		scale);
+		offset_y + style->border_size + text_y);
 	pango_cairo_update_layout(cairo, layout);
 	pango_cairo_show_layout(cairo, layout);
 
@@ -343,17 +332,18 @@ void render(struct mako_surface *surface, struct pool_buffer *buffer, int scale,
 	cairo_t *cairo = buffer->cairo;
 
 	*rendered_width = *rendered_height = 0;
+	cairo_save(cairo);
+	cairo_scale(cairo, scale, scale);
 
 	if (wl_list_empty(&state->notifications)) {
+		cairo_restore(cairo);
 		return;
 	}
-
 	// Clear
-	cairo_save(cairo);
+
 	cairo_set_source_rgba(cairo, 0, 0, 0, 0);
 	cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
 	cairo_paint(cairo);
-	cairo_restore(cairo);
 
 	size_t visible_count = 0;
 	size_t hidden_count = 0;
@@ -417,7 +407,7 @@ void render(struct mako_surface *surface, struct pool_buffer *buffer, int scale,
 
 		struct mako_icon *icon = (style->icons) ? notif->icon : NULL;
 		int notif_height = render_notification(
-			cairo, state, surface, style, text, icon, total_height, scale,
+			cairo, state, surface, style, text, icon, total_height,
 			&notif->hotspot, notif->progress);
 		free(text);
 
@@ -438,6 +428,7 @@ void render(struct mako_surface *surface, struct pool_buffer *buffer, int scale,
 			++visible_count;
 		}
 	}
+
 
 	if (hidden_count > 0) {
 		struct mako_notification *hidden_notif = create_notification(state);
@@ -470,7 +461,7 @@ void render(struct mako_surface *surface, struct pool_buffer *buffer, int scale,
 			format_text(style->format, text, format_hidden_text, &data);
 
 			int hidden_height = render_notification(
-				cairo, state, surface, style, text, NULL, total_height, scale, NULL, 0);
+				cairo, state, surface, style, text, NULL, total_height, NULL, 0);
 			free(text);
 
 			total_height += hidden_height;
@@ -481,4 +472,6 @@ void render(struct mako_surface *surface, struct pool_buffer *buffer, int scale,
 
 	*rendered_width = max_width;
 	*rendered_height = total_height;
+
+	cairo_restore(cairo);
 }


### PR DESCRIPTION
Replaced *scale with cairo_scale in render.c file . Also adjusted the draw_icon function .

Fixes #380 