### PR TITLE
Fix deprecated syntax in README commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Install dependencies:
 Then run:
 
 ```shell
-meson build
+meson setup build
 ninja -C build
 build/mako
 ```


### PR DESCRIPTION
This eliminates the message "WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated." when running meson build.