### PR TITLE
Fix bottom margin regression

### DIFF
--- a/render.c
+++ b/render.c
@@ -480,5 +480,5 @@ void render(struct mako_surface *surface, struct pool_buffer *buffer, int scale,
 	}
 
 	*rendered_width = max_width;
-	*rendered_height = total_height;
+	*rendered_height = total_height + pending_bottom_margin;
 }


### PR DESCRIPTION
Reapplies 4eb73fc which applies the bottom margin to the last notification.

Closes: https://github.com/emersion/mako/issues/647